### PR TITLE
fixes: s3upload empty upload + notif caching enabled

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -142,7 +142,7 @@ tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.i
 
 [[package]]
 name = "black"
-version = "22.1.0"
+version = "22.3.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -153,7 +153,7 @@ click = ">=8.0.0"
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
-tomli = ">=1.1.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -225,11 +225,11 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "8.0.4"
+version = "8.1.0"
 description = "Composable command line interface toolkit"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -1482,29 +1482,29 @@ attrs = [
     {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
 ]
 black = [
-    {file = "black-22.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1297c63b9e1b96a3d0da2d85d11cd9bf8664251fd69ddac068b98dc4f34f73b6"},
-    {file = "black-22.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2ff96450d3ad9ea499fc4c60e425a1439c2120cbbc1ab959ff20f7c76ec7e866"},
-    {file = "black-22.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e21e1f1efa65a50e3960edd068b6ae6d64ad6235bd8bfea116a03b21836af71"},
-    {file = "black-22.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2f69158a7d120fd641d1fa9a921d898e20d52e44a74a6fbbcc570a62a6bc8ab"},
-    {file = "black-22.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:228b5ae2c8e3d6227e4bde5920d2fc66cc3400fde7bcc74f480cb07ef0b570d5"},
-    {file = "black-22.1.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b1a5ed73ab4c482208d20434f700d514f66ffe2840f63a6252ecc43a9bc77e8a"},
-    {file = "black-22.1.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:35944b7100af4a985abfcaa860b06af15590deb1f392f06c8683b4381e8eeaf0"},
-    {file = "black-22.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7835fee5238fc0a0baf6c9268fb816b5f5cd9b8793423a75e8cd663c48d073ba"},
-    {file = "black-22.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:dae63f2dbf82882fa3b2a3c49c32bffe144970a573cd68d247af6560fc493ae1"},
-    {file = "black-22.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fa1db02410b1924b6749c245ab38d30621564e658297484952f3d8a39fce7e8"},
-    {file = "black-22.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c8226f50b8c34a14608b848dc23a46e5d08397d009446353dad45e04af0c8e28"},
-    {file = "black-22.1.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:2d6f331c02f0f40aa51a22e479c8209d37fcd520c77721c034517d44eecf5912"},
-    {file = "black-22.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:742ce9af3086e5bd07e58c8feb09dbb2b047b7f566eb5f5bc63fd455814979f3"},
-    {file = "black-22.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fdb8754b453fb15fad3f72cd9cad3e16776f0964d67cf30ebcbf10327a3777a3"},
-    {file = "black-22.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5660feab44c2e3cb24b2419b998846cbb01c23c7fe645fee45087efa3da2d61"},
-    {file = "black-22.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:6f2f01381f91c1efb1451998bd65a129b3ed6f64f79663a55fe0e9b74a5f81fd"},
-    {file = "black-22.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:efbadd9b52c060a8fc3b9658744091cb33c31f830b3f074422ed27bad2b18e8f"},
-    {file = "black-22.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8871fcb4b447206904932b54b567923e5be802b9b19b744fdff092bd2f3118d0"},
-    {file = "black-22.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ccad888050f5393f0d6029deea2a33e5ae371fd182a697313bdbd835d3edaf9c"},
-    {file = "black-22.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07e5c049442d7ca1a2fc273c79d1aecbbf1bc858f62e8184abe1ad175c4f7cc2"},
-    {file = "black-22.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:373922fc66676133ddc3e754e4509196a8c392fec3f5ca4486673e685a421321"},
-    {file = "black-22.1.0-py3-none-any.whl", hash = "sha256:3524739d76b6b3ed1132422bf9d82123cd1705086723bc3e235ca39fd21c667d"},
-    {file = "black-22.1.0.tar.gz", hash = "sha256:a7c0192d35635f6fc1174be575cb7915e92e5dd629ee79fdaf0dcfa41a80afb5"},
+    {file = "black-22.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09"},
+    {file = "black-22.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5795a0375eb87bfe902e80e0c8cfaedf8af4d49694d69161e5bd3206c18618bb"},
+    {file = "black-22.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e3556168e2e5c49629f7b0f377070240bd5511e45e25a4497bb0073d9dda776a"},
+    {file = "black-22.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67c8301ec94e3bcc8906740fe071391bce40a862b7be0b86fb5382beefecd968"},
+    {file = "black-22.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"},
+    {file = "black-22.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc1e1de68c8e5444e8f94c3670bb48a2beef0e91dddfd4fcc29595ebd90bb9ce"},
+    {file = "black-22.3.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2fc92002d44746d3e7db7cf9313cf4452f43e9ea77a2c939defce3b10b5c82"},
+    {file = "black-22.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:a6342964b43a99dbc72f72812bf88cad8f0217ae9acb47c0d4f141a6416d2d7b"},
+    {file = "black-22.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:328efc0cc70ccb23429d6be184a15ce613f676bdfc85e5fe8ea2a9354b4e9015"},
+    {file = "black-22.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06f9d8846f2340dfac80ceb20200ea5d1b3f181dd0556b47af4e8e0b24fa0a6b"},
+    {file = "black-22.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:ad4efa5fad66b903b4a5f96d91461d90b9507a812b3c5de657d544215bb7877a"},
+    {file = "black-22.3.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8477ec6bbfe0312c128e74644ac8a02ca06bcdb8982d4ee06f209be28cdf163"},
+    {file = "black-22.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:637a4014c63fbf42a692d22b55d8ad6968a946b4a6ebc385c5505d9625b6a464"},
+    {file = "black-22.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:863714200ada56cbc366dc9ae5291ceb936573155f8bf8e9de92aef51f3ad0f0"},
+    {file = "black-22.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10dbe6e6d2988049b4655b2b739f98785a884d4d6b85bc35133a8fb9a2233176"},
+    {file = "black-22.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:cee3e11161dde1b2a33a904b850b0899e0424cc331b7295f2a9698e79f9a69a0"},
+    {file = "black-22.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5891ef8abc06576985de8fa88e95ab70641de6c1fca97e2a15820a9b69e51b20"},
+    {file = "black-22.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:30d78ba6bf080eeaf0b7b875d924b15cd46fec5fd044ddfbad38c8ea9171043a"},
+    {file = "black-22.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ee8f1f7228cce7dffc2b464f07ce769f478968bfb3dd1254a4c2eeed84928aad"},
+    {file = "black-22.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ee227b696ca60dd1c507be80a6bc849a5a6ab57ac7352aad1ffec9e8b805f21"},
+    {file = "black-22.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:9b542ced1ec0ceeff5b37d69838106a6348e60db7b8fdd245294dc1d26136265"},
+    {file = "black-22.3.0-py3-none-any.whl", hash = "sha256:bc58025940a896d7e5356952228b68f793cf5fcb342be703c3a2669a1488cb72"},
+    {file = "black-22.3.0.tar.gz", hash = "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79"},
 ]
 boto3 = [
     {file = "boto3-1.20.24-py3-none-any.whl", hash = "sha256:8f08e8e94bf107c5e9866684e9aadf8d9f60abed0cfe5c1dba4e7328674a1986"},
@@ -1575,8 +1575,8 @@ charset-normalizer = [
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
-    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
-    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
+    {file = "click-8.1.0-py3-none-any.whl", hash = "sha256:19a4baa64da924c5e0cd889aba8e947f280309f1a2ce0947a3e3a7bcb7cc72d6"},
+    {file = "click-8.1.0.tar.gz", hash = "sha256:977c213473c7665d3aa092b41ff12063227751c41d7b17165013e10069cc5cd2"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},

--- a/skit_pipelines/components/__init__.py
+++ b/skit_pipelines/components/__init__.py
@@ -1,6 +1,6 @@
 from skit_pipelines.components.auth import org_auth_token_op
 from skit_pipelines.components.fetch_calls import fetch_calls_op
+from skit_pipelines.components.fetch_tagged_dataset import fetch_tagged_dataset_op
 from skit_pipelines.components.notification import slack_notification_op
 from skit_pipelines.components.tag_calls import tag_calls_op
 from skit_pipelines.components.upload2s3 import upload2s3_op
-from skit_pipelines.components.fetch_tagged_dataset import fetch_tagged_dataset_op

--- a/skit_pipelines/components/fetch_calls.py
+++ b/skit_pipelines/components/fetch_calls.py
@@ -2,12 +2,12 @@ import os
 from typing import Optional
 
 import kfp
-from kfp.components import InputPath
+from kfp.components import OutputPath
 
 from skit_pipelines import constants as pipeline_constants
 
 
-def fetch_calls(
+def fetch_calls(*,
     org_id: int,
     start_date: str,
     lang: str,
@@ -20,9 +20,8 @@ def fetch_calls(
     flow_name: Optional[str] = None,
     min_duration: Optional[str] = None,
     asr_provider: Optional[str] = None,
-    on_disk: bool = False,
-) -> InputPath():
-    import tempfile
+    output_string: OutputPath(str)
+):
     import time
     from datetime import datetime
 
@@ -64,17 +63,11 @@ def fetch_calls(
         flow_name=flow_name or None,
         min_duration=min_duration or None,
         asr_provider=asr_provider or None,
-        on_disk=on_disk or False,
+        on_disk=False,
     )
     logger.info(f"Finished in {time.time() - start:.2f} seconds")
-    if on_disk:
-        return maybe_df
-    else:
-        _, file_path = tempfile.mkstemp(suffix=const.CSV_FILE)
-        maybe_df.to_csv(file_path, index=False)
-        return file_path
-
-
+    maybe_df.to_csv(output_string, index=False)
+    
 fetch_calls_op = kfp.components.create_component_from_func(
     fetch_calls, base_image=pipeline_constants.BASE_IMAGE
 )

--- a/skit_pipelines/components/fetch_calls.py
+++ b/skit_pipelines/components/fetch_calls.py
@@ -7,7 +7,8 @@ from kfp.components import OutputPath
 from skit_pipelines import constants as pipeline_constants
 
 
-def fetch_calls(*,
+def fetch_calls(
+    *,
     org_id: int,
     start_date: str,
     lang: str,
@@ -20,7 +21,7 @@ def fetch_calls(*,
     flow_name: Optional[str] = None,
     min_duration: Optional[str] = None,
     asr_provider: Optional[str] = None,
-    output_string: OutputPath(str)
+    output_string: OutputPath(str),
 ):
     import time
     from datetime import datetime
@@ -67,7 +68,8 @@ def fetch_calls(*,
     )
     logger.info(f"Finished in {time.time() - start:.2f} seconds")
     maybe_df.to_csv(output_string, index=False)
-    
+
+
 fetch_calls_op = kfp.components.create_component_from_func(
     fetch_calls, base_image=pipeline_constants.BASE_IMAGE
 )

--- a/skit_pipelines/components/fetch_tagged_dataset.py
+++ b/skit_pipelines/components/fetch_tagged_dataset.py
@@ -2,12 +2,12 @@ import os
 from typing import Optional
 
 import kfp
-from kfp.components import InputPath
+from kfp.components import InputPath, OutputPath
 
 from skit_pipelines import constants as pipeline_constants
 
 
-def fetch_tagged_dataset(
+def fetch_tagged_dataset(*,
     job_id: str,
     task_type: Optional[str] = None,
     timezone: Optional[str] = None,
@@ -17,12 +17,14 @@ def fetch_tagged_dataset(
     password: Optional[str] = None,
     host: Optional[str] = None,
     port: Optional[int | str] = None,
-) -> InputPath():
+    output_string: OutputPath(str)
+):
     import tempfile
     import time
     import pytz
 
     from loguru import logger
+    import pandas as pd
     from skit_labels import utils
     from skit_labels import constants as const
     from skit_pipelines import constants as pipeline_constants
@@ -58,7 +60,8 @@ def fetch_tagged_dataset(
     
 
     logger.info(f"Finished in {time.time() - start:.2f} seconds")
-    return df_path
+    df = pd.read_csv(df_path)
+    df.to_csv(output_string, index=False)
 
 
 fetch_tagged_dataset_op = kfp.components.create_component_from_func(

--- a/skit_pipelines/components/fetch_tagged_dataset.py
+++ b/skit_pipelines/components/fetch_tagged_dataset.py
@@ -7,7 +7,8 @@ from kfp.components import InputPath, OutputPath
 from skit_pipelines import constants as pipeline_constants
 
 
-def fetch_tagged_dataset(*,
+def fetch_tagged_dataset(
+    *,
     job_id: str,
     task_type: Optional[str] = None,
     timezone: Optional[str] = None,
@@ -17,18 +18,19 @@ def fetch_tagged_dataset(*,
     password: Optional[str] = None,
     host: Optional[str] = None,
     port: Optional[int | str] = None,
-    output_string: OutputPath(str)
+    output_string: OutputPath(str),
 ):
     import tempfile
     import time
-    import pytz
 
-    from loguru import logger
     import pandas as pd
-    from skit_labels import utils
+    import pytz
+    from loguru import logger
     from skit_labels import constants as const
-    from skit_pipelines import constants as pipeline_constants
+    from skit_labels import utils
     from skit_labels.commands import download_dataset_from_db
+
+    from skit_pipelines import constants as pipeline_constants
 
     utils.configure_logger(7)
 
@@ -36,7 +38,6 @@ def fetch_tagged_dataset(*,
     port = port or pipeline_constants.DB_PORT
     password = password or pipeline_constants.DB_PASSWORD
     user = user or pipeline_constants.DB_USER
-
 
     if not timezone:
         timezone = pytz.UTC
@@ -56,8 +57,7 @@ def fetch_tagged_dataset(*,
         port=port,
         password=password,
         user=user,
-        )
-    
+    )
 
     logger.info(f"Finished in {time.time() - start:.2f} seconds")
     df = pd.read_csv(df_path)

--- a/skit_pipelines/components/upload2s3.py
+++ b/skit_pipelines/components/upload2s3.py
@@ -15,7 +15,7 @@ def upload2s3(
     from loguru import logger
 
     from skit_pipelines.utils import create_file_name
-    
+
     s3_resource = boto3.client("s3")
     upload_path = create_file_name(org_id, file_type, ext)
     s3_resource.upload_file(path_on_disk, bucket, upload_path)

--- a/skit_pipelines/components/upload2s3.py
+++ b/skit_pipelines/components/upload2s3.py
@@ -1,21 +1,21 @@
 import kfp
-from kfp.components import InputPath
+from kfp.components import InputPath, OutputPath
 
 from skit_pipelines import constants as pipeline_constants
 
 
 def upload2s3(
+    path_on_disk: InputPath(str),
     org_id: int,
     file_type: str,
     bucket: str,
-    path_on_disk: InputPath(),
     ext: str = ".csv",
 ) -> str:
     import boto3
     from loguru import logger
 
     from skit_pipelines.utils import create_file_name
-
+    
     s3_resource = boto3.client("s3")
     upload_path = create_file_name(org_id, file_type, ext)
     s3_resource.upload_file(path_on_disk, bucket, upload_path)

--- a/skit_pipelines/pipelines/fetch_calls_pipeline.py
+++ b/skit_pipelines/pipelines/fetch_calls_pipeline.py
@@ -43,11 +43,13 @@ def run_fetch_calls(
         asr_provider=asr_provider,
     )
     s3_upload = upload2s3_op(
-        org_id,
-        f"{lang}-untagged",
-        pipeline_constants.BUCKET,
+        calls.outputs["output_string"],
+        org_id=org_id,
+        file_type=f"{lang}-untagged",
+        bucket=pipeline_constants.BUCKET,
         ext=".csv",
-        path_on_disk=calls.output,
     )
+    s3_upload.execution_options.caching_strategy.max_cache_staleness = "P0D" # disables caching
     notification_text = f"Finished a request for {call_quantity} calls. Fetched from {start_date} to {end_date} for {org_id=}."
-    slack_notification_op(notification_text, s3_path=s3_upload.output)
+    task_no_cache = slack_notification_op(notification_text, s3_path=s3_upload.output)
+    task_no_cache.execution_options.caching_strategy.max_cache_staleness = "P0D" # disables caching

--- a/skit_pipelines/pipelines/fetch_calls_pipeline.py
+++ b/skit_pipelines/pipelines/fetch_calls_pipeline.py
@@ -49,7 +49,11 @@ def run_fetch_calls(
         bucket=pipeline_constants.BUCKET,
         ext=".csv",
     )
-    s3_upload.execution_options.caching_strategy.max_cache_staleness = "P0D" # disables caching
+    s3_upload.execution_options.caching_strategy.max_cache_staleness = (
+        "P0D"  # disables caching
+    )
     notification_text = f"Finished a request for {call_quantity} calls. Fetched from {start_date} to {end_date} for {org_id=}."
     task_no_cache = slack_notification_op(notification_text, s3_path=s3_upload.output)
-    task_no_cache.execution_options.caching_strategy.max_cache_staleness = "P0D" # disables caching
+    task_no_cache.execution_options.caching_strategy.max_cache_staleness = (
+        "P0D"  # disables caching
+    )

--- a/skit_pipelines/pipelines/fetch_tagged_dataset_pipeline.py
+++ b/skit_pipelines/pipelines/fetch_tagged_dataset_pipeline.py
@@ -32,11 +32,13 @@ def run_fetch_tagged_dataset(
     )
 
     s3_upload = upload2s3_op(
-        org_id,
-        f"tagged",
-        pipeline_constants.BUCKET,
+        path_on_disk=calls.outputs['output_string'],
+        org_id=org_id,
+        file_type=f"tagged",
+        bucket=pipeline_constants.BUCKET,
         ext=".csv",
-        path_on_disk=calls.output,
     )
-    notification_text = f"Here is your data."
-    slack_notification_op(notification_text, s3_path=s3_upload.output)
+    
+    notification_text = f"Here is your data for {org_id=} and {job_id=}."
+    task_no_cache = slack_notification_op(notification_text, s3_path=s3_upload.output)
+    task_no_cache.execution_options.caching_strategy.max_cache_staleness = "P0D" # disables caching

--- a/skit_pipelines/pipelines/fetch_tagged_dataset_pipeline.py
+++ b/skit_pipelines/pipelines/fetch_tagged_dataset_pipeline.py
@@ -1,13 +1,15 @@
+import os
 from typing import Optional
 
 import kfp
-import os
+
+from skit_pipelines import constants as pipeline_constants
 from skit_pipelines.components import (
     fetch_tagged_dataset_op,
     slack_notification_op,
     upload2s3_op,
 )
-from skit_pipelines import constants as pipeline_constants
+
 
 @kfp.dsl.pipeline(
     name="Fetch Tagged Dataset Pipeline",
@@ -20,7 +22,7 @@ def run_fetch_tagged_dataset(
     timezone: str,
     start_date: str,
     end_date: str,
-): 
+):
 
     calls = fetch_tagged_dataset_op(
         job_id=job_id,
@@ -28,17 +30,18 @@ def run_fetch_tagged_dataset(
         timezone=timezone,
         start_date=start_date,
         end_date=end_date,
-
     )
 
     s3_upload = upload2s3_op(
-        path_on_disk=calls.outputs['output_string'],
+        path_on_disk=calls.outputs["output_string"],
         org_id=org_id,
         file_type=f"tagged",
         bucket=pipeline_constants.BUCKET,
         ext=".csv",
     )
-    
+
     notification_text = f"Here is your data for {org_id=} and {job_id=}."
     task_no_cache = slack_notification_op(notification_text, s3_path=s3_upload.output)
-    task_no_cache.execution_options.caching_strategy.max_cache_staleness = "P0D" # disables caching
+    task_no_cache.execution_options.caching_strategy.max_cache_staleness = (
+        "P0D"  # disables caching
+    )


### PR DESCRIPTION
- s3upload component upload URI containing file-path only.
- notification component being cached on fetch-calls and fetch-tagged-dataset pipelines.