### PR TITLE
new pipeline for fetching and tagging calls + structure changes

### DIFF
--- a/skit_pipelines/components/__init__.py
+++ b/skit_pipelines/components/__init__.py
@@ -13,3 +13,4 @@ from skit_pipelines.components.preprocess.create_utterance_column import (
 from skit_pipelines.components.tag_calls import tag_calls_op
 from skit_pipelines.components.train_voicebot_xlmr import train_xlmr_voicebot_op
 from skit_pipelines.components.upload2s3 import upload2s3_op
+from skit_pipelines.components.get_serialized_value import get_value_op

--- a/skit_pipelines/components/__init__.py
+++ b/skit_pipelines/components/__init__.py
@@ -10,7 +10,7 @@ from skit_pipelines.components.preprocess.create_true_intent_column import (
 from skit_pipelines.components.preprocess.create_utterance_column import (
     create_utterances_op,
 )
+from skit_pipelines.components.read_json_key import read_json_key_op
 from skit_pipelines.components.tag_calls import tag_calls_op
 from skit_pipelines.components.train_voicebot_xlmr import train_xlmr_voicebot_op
-from skit_pipelines.components.upload2s3 import upload2s3_op, upload2s3
-from skit_pipelines.components.read_json_key import read_json_key_op
+from skit_pipelines.components.upload2s3 import upload2s3, upload2s3_op

--- a/skit_pipelines/components/__init__.py
+++ b/skit_pipelines/components/__init__.py
@@ -12,5 +12,5 @@ from skit_pipelines.components.preprocess.create_utterance_column import (
 )
 from skit_pipelines.components.tag_calls import tag_calls_op
 from skit_pipelines.components.train_voicebot_xlmr import train_xlmr_voicebot_op
-from skit_pipelines.components.upload2s3 import upload2s3_op
-from skit_pipelines.components.get_serialized_value import get_value_op
+from skit_pipelines.components.upload2s3 import upload2s3_op, upload2s3
+from skit_pipelines.components.read_json_key import read_json_key_op

--- a/skit_pipelines/components/fetch_calls.py
+++ b/skit_pipelines/components/fetch_calls.py
@@ -19,10 +19,10 @@ def fetch_calls(
     use_case: Optional[str] = None,
     flow_name: Optional[str] = None,
     min_duration: Optional[str] = None,
-    asr_provider: Optional[str] = None
+    asr_provider: Optional[str] = None,
 ) -> str:
-    import time
     import tempfile
+    import time
     from datetime import datetime
 
     from loguru import logger
@@ -30,9 +30,9 @@ def fetch_calls(
     from skit_calls import constants as const
     from skit_calls import utils
     from skit_calls.cli import process_date_filters, to_datetime, validate_date_ranges
-    
-    from skit_pipelines.components import upload2s3
+
     from skit_pipelines import constants as pipeline_constants
+    from skit_pipelines.components import upload2s3
 
     utils.configure_logger(7)
 
@@ -71,7 +71,7 @@ def fetch_calls(
     logger.info(f"Finished in {time.time() - start:.2f} seconds")
     _, file_path = tempfile.mkstemp(suffix=const.CSV_FILE)
     maybe_df.to_csv(file_path, index=False)
-    
+
     s3_path = upload2s3(
         file_path,
         org_id=client_id,

--- a/skit_pipelines/components/fetch_calls.py
+++ b/skit_pipelines/components/fetch_calls.py
@@ -19,10 +19,10 @@ def fetch_calls(
     use_case: Optional[str] = None,
     flow_name: Optional[str] = None,
     min_duration: Optional[str] = None,
-    asr_provider: Optional[str] = None,
-    output_string: OutputPath(str),
-):
+    asr_provider: Optional[str] = None
+) -> str:
     import time
+    import tempfile
     from datetime import datetime
 
     from loguru import logger
@@ -30,6 +30,9 @@ def fetch_calls(
     from skit_calls import constants as const
     from skit_calls import utils
     from skit_calls.cli import process_date_filters, to_datetime, validate_date_ranges
+    
+    from skit_pipelines.components import upload2s3
+    from skit_pipelines import constants as pipeline_constants
 
     utils.configure_logger(7)
 
@@ -66,7 +69,17 @@ def fetch_calls(
         on_disk=False,
     )
     logger.info(f"Finished in {time.time() - start:.2f} seconds")
-    maybe_df.to_csv(output_string, index=False)
+    _, file_path = tempfile.mkstemp(suffix=const.CSV_FILE)
+    maybe_df.to_csv(file_path, index=False)
+    
+    s3_path = upload2s3(
+        file_path,
+        org_id=client_id,
+        file_type=f"{lang}-untagged",
+        bucket=pipeline_constants.BUCKET,
+        ext=".csv",
+    )
+    return s3_path
 
 
 fetch_calls_op = kfp.components.create_component_from_func(

--- a/skit_pipelines/components/fetch_calls.py
+++ b/skit_pipelines/components/fetch_calls.py
@@ -8,7 +8,7 @@ from skit_pipelines import constants as pipeline_constants
 
 def fetch_calls(
     *,
-    org_id: int,
+    client_id: int,
     start_date: str,
     lang: str,
     end_date: Optional[str] = None,
@@ -51,7 +51,7 @@ def fetch_calls(
 
     start = time.time()
     maybe_df = calls.sample(
-        org_id,
+        client_id,
         start_date,
         end_date,
         lang,

--- a/skit_pipelines/components/get_serialized_value.py
+++ b/skit_pipelines/components/get_serialized_value.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+import kfp
+from kfp.components import InputPath
+
+from skit_pipelines import constants as pipeline_constants
+
+
+def get_value(
+    req_value: str, input_file: InputPath(str)
+) -> Any:
+
+    import os
+    import json    
+    from loguru import logger
+    
+    serialized_obj = {}
+    if os.path.isfile(input_file):
+        with open(input_file, "r") as j_read:
+            serialized_obj = json.load(j_read)
+    
+    logger.info(f"{serialized_obj=}")
+    return serialized_obj.get(req_value)
+
+get_value_op = kfp.components.create_component_from_func(
+    get_value, base_image=pipeline_constants.BASE_IMAGE
+)

--- a/skit_pipelines/components/read_json_key.py
+++ b/skit_pipelines/components/read_json_key.py
@@ -6,7 +6,7 @@ from kfp.components import InputPath
 from skit_pipelines import constants as pipeline_constants
 
 
-def get_value(
+def read_json_key(
     req_value: str, input_file: InputPath(str)
 ) -> Any:
 
@@ -20,8 +20,10 @@ def get_value(
             serialized_obj = json.load(j_read)
     
     logger.info(f"{serialized_obj=}")
-    return serialized_obj.get(req_value)
+    val = serialized_obj.get(req_value)
+    logger.info(f"requested key: {req_value} = {val}")
+    return val
 
-get_value_op = kfp.components.create_component_from_func(
-    get_value, base_image=pipeline_constants.BASE_IMAGE
+read_json_key_op = kfp.components.create_component_from_func(
+    read_json_key, base_image=pipeline_constants.BASE_IMAGE
 )

--- a/skit_pipelines/components/read_json_key.py
+++ b/skit_pipelines/components/read_json_key.py
@@ -6,23 +6,23 @@ from kfp.components import InputPath
 from skit_pipelines import constants as pipeline_constants
 
 
-def read_json_key(
-    req_value: str, input_file: InputPath(str)
-) -> Any:
-
-    import os
-    import json    
-    from loguru import logger
+def read_json_key(req_value: str, input_file: InputPath(str)) -> Any:
     
+    import json
+    import os
+
+    from loguru import logger
+
     serialized_obj = {}
     if os.path.isfile(input_file):
         with open(input_file, "r") as j_read:
             serialized_obj = json.load(j_read)
-    
+
     logger.info(f"{serialized_obj=}")
     val = serialized_obj.get(req_value)
     logger.info(f"requested key: {req_value} = {val}")
     return val
+
 
 read_json_key_op = kfp.components.create_component_from_func(
     read_json_key, base_image=pipeline_constants.BASE_IMAGE

--- a/skit_pipelines/components/tag_calls.py
+++ b/skit_pipelines/components/tag_calls.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple
-
 import kfp
 from kfp.components import InputPath, OutputPath
 
@@ -26,7 +24,7 @@ def tag_calls(
     
     if os.path.isfile(input_file):
         with open(input_file, "r") as f:
-            input_file = f.read(input_file)
+            input_file = f.read()
             
     with open(token, "r") as reader:
         token = reader.read()

--- a/skit_pipelines/components/tag_calls.py
+++ b/skit_pipelines/components/tag_calls.py
@@ -1,17 +1,19 @@
 from typing import List, Tuple
 
 import kfp
-from kfp.components import InputPath
+from kfp.components import InputPath, OutputPath
 
 from skit_pipelines import constants as pipeline_constants
 
 
 def tag_calls(
-    input_file: str, job_id: int, token: InputPath(str), url: str = None
-) -> Tuple[int, List[str]]:
+    *, input_file: str, job_id: int, token: InputPath(str), url: str = None, output_json: OutputPath(str)
+):
 
     import time
-
+    import os
+    import json
+    
     from loguru import logger
     from skit_labels import utils
     from skit_labels.cli import upload_dataset
@@ -21,13 +23,23 @@ def tag_calls(
     utils.configure_logger(7)
 
     url = pipeline_constants.CONSOLE_API_URL if url is None else url
+    
+    if os.path.isfile(input_file):
+        with open(input_file, "r") as f:
+            input_file = f.read(input_file)
+            
     with open(token, "r") as reader:
         token = reader.read()
     start = time.time()
     errors, df_size = upload_dataset(input_file, url, token, job_id)
+    # write to json
+    with open(output_json, "w") as writer:
+        json.dump(
+            {"errors": errors, "df_size": df_size},
+            writer, indent=4
+        )
     logger.info(f"Uploaded in {time.time() - start:.2f} seconds to {job_id=}")
     logger.info(f"{df_size=} rows in the dataset")
-    return df_size, errors
 
 
 tag_calls_op = kfp.components.create_component_from_func(

--- a/skit_pipelines/components/tag_calls.py
+++ b/skit_pipelines/components/tag_calls.py
@@ -5,13 +5,18 @@ from skit_pipelines import constants as pipeline_constants
 
 
 def tag_calls(
-    *, input_file: str, job_id: int, token: InputPath(str), url: str = None, output_json: OutputPath(str)
+    *,
+    input_file: str,
+    job_id: int,
+    token: InputPath(str),
+    url: str = None,
+    output_json: OutputPath(str),
 ):
 
-    import time
-    import os
     import json
-    
+    import os
+    import time
+
     from loguru import logger
     from skit_labels import utils
     from skit_labels.cli import upload_dataset
@@ -21,21 +26,18 @@ def tag_calls(
     utils.configure_logger(7)
 
     url = pipeline_constants.CONSOLE_API_URL if url is None else url
-    
+
     if os.path.isfile(input_file):
         with open(input_file, "r") as f:
             input_file = f.read()
-            
+
     with open(token, "r") as reader:
         token = reader.read()
     start = time.time()
     errors, df_size = upload_dataset(input_file, url, token, job_id)
     # write to json
     with open(output_json, "w") as writer:
-        json.dump(
-            {"errors": errors, "df_size": df_size},
-            writer, indent=4
-        )
+        json.dump({"errors": errors, "df_size": df_size}, writer, indent=4)
     logger.info(f"Uploaded in {time.time() - start:.2f} seconds to {job_id=}")
     logger.info(f"{df_size=} rows in the dataset")
 

--- a/skit_pipelines/components/train_voicebot_xlmr.py
+++ b/skit_pipelines/components/train_voicebot_xlmr.py
@@ -15,7 +15,7 @@ def train_xlmr_voicebot(
     use_early_stopping: bool = False,
     early_stopping_patience: int = 3,
     early_stopping_delta: float = 0,
-    max_seq_length: int = 128
+    max_seq_length: int = 128,
 ):
     # HACK: This code should go as soon as this issue is fixed:
     # https://github.com/ThilinaRajapakse/simpletransformers/issues/1386

--- a/skit_pipelines/components/upload2s3.py
+++ b/skit_pipelines/components/upload2s3.py
@@ -16,8 +16,9 @@ def upload2s3(
 
     import boto3
     from loguru import logger
-    from skit_pipelines.utils import create_file_name, create_dir_name
-    
+
+    from skit_pipelines.utils import create_dir_name, create_file_name
+
     s3_resource = boto3.client("s3")
 
     if os.path.isfile(path_on_disk):
@@ -29,7 +30,9 @@ def upload2s3(
             if not os.path.isfile(full_file_path):
                 continue
             _, file_path = os.path.split(full_file_path)
-            s3_resource.upload_file(full_file_path, bucket, os.path.join(upload_path, file_path))
+            s3_resource.upload_file(
+                full_file_path, bucket, os.path.join(upload_path, file_path)
+            )
 
     s3_path = f"s3://{bucket}/{upload_path}"
     logger.debug(f"Uploaded {path_on_disk} to {upload_path}")

--- a/skit_pipelines/components/upload2s3.py
+++ b/skit_pipelines/components/upload2s3.py
@@ -36,7 +36,6 @@ def upload2s3(
     return s3_path
 
 
-
 upload2s3_op = kfp.components.create_component_from_func(
     upload2s3, base_image=pipeline_constants.BASE_IMAGE
 )

--- a/skit_pipelines/components/upload2s3.py
+++ b/skit_pipelines/components/upload2s3.py
@@ -1,6 +1,5 @@
 import kfp
 from kfp.components import InputPath
-from numpy import full
 
 from skit_pipelines import constants as pipeline_constants
 
@@ -23,7 +22,7 @@ def upload2s3(
 
     if os.path.isfile(path_on_disk):
         upload_path = create_file_name(org_id, file_type, ext)
-        s3_resource.upload_file(path_on_disk, bucket, )
+        s3_resource.upload_file(path_on_disk, bucket, upload_path)
     elif os.path.isdir(path_on_disk):
         upload_path = create_dir_name(org_id, file_type)
         for full_file_path in glob(f"{path_on_disk}/**", recursive=True):

--- a/skit_pipelines/pipelines/fetch_calls_pipeline.py
+++ b/skit_pipelines/pipelines/fetch_calls_pipeline.py
@@ -1,10 +1,8 @@
 import kfp
 
-from skit_pipelines import constants as pipeline_constants
 from skit_pipelines.components import (
     fetch_calls_op,
     slack_notification_op,
-    upload2s3_op,
 )
 
 
@@ -40,18 +38,9 @@ def run_fetch_calls(
         min_duration=min_duration,
         asr_provider=asr_provider,
     )
-    s3_upload = upload2s3_op(
-        calls.outputs["output_string"],
-        org_id=client_id,
-        file_type=f"{lang}-untagged",
-        bucket=pipeline_constants.BUCKET,
-        ext=".csv",
-    )
-    s3_upload.execution_options.caching_strategy.max_cache_staleness = (
-        "P0D"  # disables caching
-    )
+    
     notification_text = f"Finished a request for {call_quantity} calls. Fetched from {start_date} to {end_date} for {client_id=}."
-    task_no_cache = slack_notification_op(notification_text, s3_path=s3_upload.output)
+    task_no_cache = slack_notification_op(notification_text, s3_path=calls.output)
     task_no_cache.execution_options.caching_strategy.max_cache_staleness = (
         "P0D"  # disables caching
     )

--- a/skit_pipelines/pipelines/fetch_calls_pipeline.py
+++ b/skit_pipelines/pipelines/fetch_calls_pipeline.py
@@ -1,9 +1,6 @@
 import kfp
 
-from skit_pipelines.components import (
-    fetch_calls_op,
-    slack_notification_op,
-)
+from skit_pipelines.components import fetch_calls_op, slack_notification_op
 
 
 @kfp.dsl.pipeline(
@@ -38,7 +35,7 @@ def run_fetch_calls(
         min_duration=min_duration,
         asr_provider=asr_provider,
     )
-    
+
     notification_text = f"Finished a request for {call_quantity} calls. Fetched from {start_date} to {end_date} for {client_id=}."
     task_no_cache = slack_notification_op(notification_text, s3_path=calls.output)
     task_no_cache.execution_options.caching_strategy.max_cache_staleness = (

--- a/skit_pipelines/pipelines/fetch_n_tag_calls_pipeline.py
+++ b/skit_pipelines/pipelines/fetch_n_tag_calls_pipeline.py
@@ -5,15 +5,19 @@ from skit_pipelines.components import (
     fetch_calls_op,
     slack_notification_op,
     upload2s3_op,
+    org_auth_token_op,
+    tag_calls_op,
 )
 
 
 @kfp.dsl.pipeline(
-    name="Fetch Calls Pipeline",
-    description="fetches calls from production db with respective arguments",
+    name="Fetch and push for tagging calls pipeline",
+    description="fetches calls from production db with respective arguments and uploads calls to database for tagging",
 )
-def run_fetch_calls(
+def run_fetch_n_tag_calls(
     client_id: int,
+    org_id: int,
+    job_id: int,
     start_date: str,
     lang: str,
     end_date: str,
@@ -50,8 +54,24 @@ def run_fetch_calls(
     s3_upload.execution_options.caching_strategy.max_cache_staleness = (
         "P0D"  # disables caching
     )
-    notification_text = f"Finished a request for {call_quantity} calls. Fetched from {start_date} to {end_date} for {client_id=}."
-    task_no_cache = slack_notification_op(notification_text, s3_path=s3_upload.output)
+    
+    auth_token = org_auth_token_op(org_id)
+    tag_calls_output = tag_calls_op(
+        input_file=s3_upload.output,
+        job_id=job_id,
+        token=auth_token.output,
+    )
+    df_size, errors = tag_calls_output.outputs
+    
+    notification_text = (
+        f"""Finished a request for {call_quantity} calls. Fetched from {start_date} to {end_date} for {client_id=}.
+        Uploaded {s3_upload} ({df_size}, {org_id=}) for tagging to {job_id=}."""
+    )
+    print(tag_calls_output.output)
+    with kfp.dsl.Condition(tag_calls_output.output):
+        notification_text += f" Errors: {errors=}"
+        
+    task_no_cache = slack_notification_op(notification_text, "").after(tag_calls_output)
     task_no_cache.execution_options.caching_strategy.max_cache_staleness = (
         "P0D"  # disables caching
     )

--- a/skit_pipelines/pipelines/tag_calls_pipeline.py
+++ b/skit_pipelines/pipelines/tag_calls_pipeline.py
@@ -1,11 +1,10 @@
 import kfp
 
-from skit_pipelines import constants as pipeline_constants
 from skit_pipelines.components import (
     org_auth_token_op,
     slack_notification_op,
     tag_calls_op,
-    get_value_op
+    read_json_key_op
 )
 
 
@@ -20,15 +19,17 @@ def run_tag_calls(org_id: int, job_id: int, s3_path: str):
         job_id=job_id,
         token=auth_token.output,
     )
-    df_size = get_value_op('df_size', tag_calls_output.outputs["output_json"])
-    errors = get_value_op('errors', tag_calls_output.outputs["output_json"])
+    df_size = read_json_key_op('df_size', tag_calls_output.outputs["output_json"])
+    df_size.display_name = "get-df-size"
+    errors = read_json_key_op('errors', tag_calls_output.outputs["output_json"])
+    errors.display_name = "get-any-errors"
     
     notification_text = (
         f"Uploaded {s3_path} ({df_size}, {org_id=}) for tagging to {job_id=}."
     )
-    if errors:
+    with kfp.dsl.Condition(errors.output != [], "check_any_errors").after(errors) as check1:
         notification_text += f" Errors: {errors=}"
-    task_no_cache = slack_notification_op(notification_text, "")
+    task_no_cache = slack_notification_op(notification_text, "").after(check1)
     task_no_cache.execution_options.caching_strategy.max_cache_staleness = (
         "P0D"  # disables caching
     )

--- a/skit_pipelines/pipelines/tag_calls_pipeline.py
+++ b/skit_pipelines/pipelines/tag_calls_pipeline.py
@@ -5,6 +5,7 @@ from skit_pipelines.components import (
     org_auth_token_op,
     slack_notification_op,
     tag_calls_op,
+    get_value_op
 )
 
 
@@ -19,7 +20,9 @@ def run_tag_calls(org_id: int, job_id: int, s3_path: str):
         job_id=job_id,
         token=auth_token.output,
     )
-    df_size, errors = tag_calls_output.outputs
+    df_size = get_value_op('df_size', tag_calls_output.outputs["output_json"])
+    errors = get_value_op('errors', tag_calls_output.outputs["output_json"])
+    
     notification_text = (
         f"Uploaded {s3_path} ({df_size}, {org_id=}) for tagging to {job_id=}."
     )

--- a/skit_pipelines/pipelines/train_voicebot_xlmr_pipeline.py
+++ b/skit_pipelines/pipelines/train_voicebot_xlmr_pipeline.py
@@ -6,8 +6,8 @@ from skit_pipelines.components import (
     create_true_intent_labels_op,
     create_utterances_op,
     download_from_s3_op,
-    upload2s3_op,
     train_xlmr_voicebot_op,
+    upload2s3_op,
 )
 
 UTTERANCES = pipeline_constants.UTTERANCES
@@ -29,7 +29,7 @@ def run_fetch_tagged_dataset(
     use_early_stopping: bool = False,
     early_stopping_patience: int = 3,
     early_stopping_delta: float = 0,
-    max_seq_length: int = 128
+    max_seq_length: int = 128,
 ):
     tagged_data_op = download_from_s3_op(s3_path)
     # preprocess the file
@@ -38,12 +38,16 @@ def run_fetch_tagged_dataset(
     preprocess_data_op = create_utterances_op(tagged_data_op.outputs["output"])
 
     # Create utterance column
-    preprocess_data_op = create_true_intent_labels_op(preprocess_data_op.outputs["output"])
+    preprocess_data_op = create_true_intent_labels_op(
+        preprocess_data_op.outputs["output"]
+    )
 
     # Create train and test splits
 
     # Normalize utterance column
-    preprocess_data_op = create_features_op(preprocess_data_op.outputs["output"], use_state)
+    preprocess_data_op = create_features_op(
+        preprocess_data_op.outputs["output"], use_state
+    )
 
     train_op = train_xlmr_voicebot_op(
         preprocess_data_op.outputs["output"],

--- a/skit_pipelines/utils/__init__.py
+++ b/skit_pipelines/utils/__init__.py
@@ -14,10 +14,7 @@ def create_file_name(org_id: int, file_type: str, ext=".csv") -> str:
 
 def create_dir_name(org_id: int, dir_type: str) -> str:
     return os.path.join(
-        "project",
-        str(org_id),
-        datetime.now().strftime("%Y-%m-%d"),
-        dir_type
+        "project", str(org_id), datetime.now().strftime("%Y-%m-%d"), dir_type
     )
 
 


### PR DESCRIPTION
- new pipeline which can fetch untagged calls and push it for tagging to database in single run
- new component `read_json_key`
- tag_calls component return structure change - stores multiple required return values into a json and `read_json_key` can be used to read it inside pipeline.
- fetch_calls component structure change for no ephemeral container storage only (now returns s3 path after uploading within component) and renamed misleading name `org_id` to `client_id` for it.
- s3upload for file bug fix (key missing)