### PR TITLE
automated config based pipeline endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ test_auth_kf.py
 *.csv
 /sql
 /secrets
+
+.history

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+
+### Note
+* the main function of our interest inside a pipeline file should start with `run_`.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,25 @@
+
+pipelines:
+
+    fetch-calls:
+        default_run: "default-fetch-calls-run"
+        output_component: "fetch-calls"
+        main_function: "run_fetch_calls"
+        topic: "data-pipeline"
+
+    tag-calls:
+        default_run: "default-tag-calls-run"
+        output_component: "tag-calls"
+        main_function: "run_tag_calls"
+        topic: "data-pipeline"
+    
+    train-voicebot-xlmr:
+        default_run: "default-train-voicebot-xlmr-run"
+        output_component: "train-voicebot-xlmr"
+        main_function: "run_xlmr_train"
+        topic: "model-train-pipeline"
+
+
+publisher_topics:
+    - "data-pipeline"
+    - "model-train-pipeline"

--- a/consumer.py
+++ b/consumer.py
@@ -1,0 +1,45 @@
+from typing import List, Dict, Any
+import json
+import requests
+from kafka import KafkaConsumer
+
+# ConsumerRecord(topic='data-pipeline', partition=0, offset=0, timestamp=1651317435380, timestamp_type=0, key=None, value=b'{"status":"ok",...}', headers=[], checksum=None, serialized_key_size=-1, serialized_value_size=341, serialized_header_size=-1)
+
+# example Kafka Consumer 
+consumer = KafkaConsumer(
+    'data-pipeline',
+    'model-train-pipeline',
+    bootstrap_servers='localhost:19092',
+    auto_offset_reset='latest'
+)
+for message in consumer:
+    print(json.loads(message.value))
+
+
+def start_consumer(
+    topics: List[str],
+    bootstrap_servers: List[str],
+    auto_offset_reset: str ='latest'
+) -> KafkaConsumer:
+    """
+    Start a Kafka consumer
+    """
+    consumer = KafkaConsumer(
+        *topics,
+        bootstrap_servers=bootstrap_servers,
+        auto_offset_reset=auto_offset_reset
+    )
+    return consumer
+
+
+def send_finished_runs(url_path: str, data: Dict[str, Any]):
+    """
+    Send finished runs to the server
+    """
+    
+    response = requests.post(url_path, json=data)
+    return response
+
+def consume_finished_runs(consumer: KafkaConsumer):
+    for message in consumer:
+        send_finished_runs(message.value)

--- a/skit_pipelines/api/endpoints.py
+++ b/skit_pipelines/api/endpoints.py
@@ -7,11 +7,7 @@ from aiokafka import AIOKafkaProducer
 from kfp_server_api.models.api_run_detail import ApiRunDetail as kfp_ApiRunDetail
 
 from skit_pipelines.api import app, models, BackgroundTasks, run_in_threadpool
-from skit_pipelines.pipelines import (
-    run_fetch_calls,
-    run_tag_calls,
-    run_xlmr_train
-)
+import skit_pipelines.utils.config as config
 from skit_pipelines.utils import kubeflow_login
 import skit_pipelines.constants as const
 
@@ -95,45 +91,24 @@ def get_run_info(
     parsed_resp = models.ParseRunResponse(run=run_resp, component_display_name=pipeline_name)
     return models.statusWiseResponse(parsed_resp)
 
-
-@app.post("/{namespace}/pipelines/run/fetch-calls/")
-def fetch_calls_req(*,
+@app.post("/{namespace}/pipelines/run/{pipeline_name}/")
+def pipeline_run_req(*,
     namespace: str,
-    payload: models.FetchCallSchema,
-    run_name: str = const.DEFAULT_FETCH_CALLS_API_RUN,
-    component_name: str = const.FETCH_CALLS_NAME,
+    pipeline_name: str,
+    run_name: str | None = None,
+    component_name: str | None = None,
+    payload: models.ValidRequestSchemas,
     background_tasks: BackgroundTasks
 ):
-    run = call_kfp_method(
-        pipeline_func=run_fetch_calls,
-        run_name=run_name,
-        namespace=namespace,
-        arguments=payload.dict()
-    )
-    background_tasks.add_task(
-        schedule_run_completion,
-        client_resp=run,
-        namespace=namespace,
-        component_name=component_name,
-        payload=payload
-    )
-    return models.successfulCreationResponse(
-        run_id=run.run_id,
-        name=const.FETCH_CALLS_NAME,
-        namespace=namespace
-    )
+    if not config.valid_pipeline(pipeline_name):
+        raise models.errors.kfp_invalid_name(
+            f"Invalid pipeline requested, check if it exists: {pipeline_name}"
+        )
     
-
-@app.post("/{namespace}/pipelines/run/tag-calls/")
-def tag_calls_req(*,
-    namespace: str,
-    payload: models.TagCallSchema,
-    run_name: str = const.DEFAULT_TAG_CALLS_API_RUN,
-    component_name: str = const.TAG_CALLS_NAME,
-    background_tasks: BackgroundTasks
-):
+    run_name = run_name if run_name else config.RUN_NAME_MAP[pipeline_name]
+    component_name = component_name if component_name else pipeline_name
     run = call_kfp_method(
-        pipeline_func=run_tag_calls,
+        pipeline_func=config.PIPELINE_FN_MAP[pipeline_name],
         run_name=run_name,
         namespace=namespace,
         arguments=payload.dict()
@@ -147,44 +122,17 @@ def tag_calls_req(*,
     )
     return models.successfulCreationResponse(
         run_id=run.run_id,
-        name=const.TAG_CALLS_NAME,
+        name=pipeline_name,
         namespace=namespace
     )
 
-
-@app.post("/{namespace}/pipelines/run/train-voicebot-xlmr/")
-def xlmr_train_req(*,
-    namespace: str,
-    payload: models.TrainModelSchema,
-    run_name: str = const.DEFAULT_XLMR_MODEL_API_RUN,
-    component_name: str = const.TRAIN_XLMR_NAME,
-    background_tasks: BackgroundTasks
-):
-    run = call_kfp_method(
-        pipeline_func=run_xlmr_train,
-        run_name=run_name,
-        namespace=namespace,
-        arguments=payload.dict()
-    )
-    background_tasks.add_task(
-        schedule_run_completion,
-        client_resp=run,
-        namespace=namespace,
-        component_name=component_name,
-        payload=payload
-    )
-    return models.successfulCreationResponse(
-        run_id=run.run_id,
-        name=const.TRAIN_XLMR_NAME,
-        namespace=namespace
-    )
 
 
 @app.exception_handler(kfp_server_api.ApiException)
 async def kfp_api_exception_handler(request, exc):
     return models.customResponse(
         status_code=exc.status,
-        message_dict=f"{exc}",
+        message=f"{exc}",
         status="error",
     )
 

--- a/skit_pipelines/api/endpoints.py
+++ b/skit_pipelines/api/endpoints.py
@@ -40,7 +40,7 @@ async def schedule_run_completion(
     logger.info(f"Pipeline run for {component_name} finished!")
     parsed_resp = models.ParseRunResponse(run=run_resp, component_display_name=component_name)
     msg = models.statusWiseResponse(parsed_resp)
-    await aioproducer.send(const.KAFKA_TOPIC_MAP[component_name], msg.body)
+    await aioproducer.send(config.KAFKA_TOPIC_MAP[component_name], msg.body)
     logger.info((f"Results sent to queue."))
 
 

--- a/skit_pipelines/api/endpoints.py
+++ b/skit_pipelines/api/endpoints.py
@@ -7,7 +7,7 @@ from aiokafka import AIOKafkaProducer
 from kfp_server_api.models.api_run_detail import ApiRunDetail as kfp_ApiRunDetail
 
 from skit_pipelines.api import app, models, BackgroundTasks, run_in_threadpool
-import skit_pipelines.utils.config as config
+from skit_pipelines.utils.config import config
 from skit_pipelines.utils import kubeflow_login
 import skit_pipelines.constants as const
 

--- a/skit_pipelines/api/endpoints.py
+++ b/skit_pipelines/api/endpoints.py
@@ -71,8 +71,7 @@ def health_check():
     if KF_CLIENT.get_kfp_healthz().multi_user:
         return models.customResponse("Kubeflow server communication is up!")
     else:
-        raise kfp_server_api.ApiException(
-            status=503,
+        raise models.errors.kfp_api_error(
             reason="Unable to communicate with Kubeflow server..."
         )
 
@@ -101,8 +100,9 @@ def pipeline_run_req(*,
     background_tasks: BackgroundTasks
 ):
     if not config.valid_pipeline(pipeline_name):
-        raise models.errors.kfp_invalid_name(
-            f"Invalid pipeline requested, check if it exists: {pipeline_name}"
+        raise models.errors.kfp_api_error(
+            reason=f"Invalid pipeline requested, check if it exists: {pipeline_name}",
+            status=400
         )
     
     run_name = run_name if run_name else config.RUN_NAME_MAP[pipeline_name]

--- a/skit_pipelines/api/models/__init__.py
+++ b/skit_pipelines/api/models/__init__.py
@@ -3,3 +3,13 @@ from skit_pipelines.api.models.requests import (
 )
 from skit_pipelines.api.models.responses import customResponse, statusWiseResponse, successfulCreationResponse
 from skit_pipelines.api.models.custom_models import ParseRunResponse
+
+import skit_pipelines.api.models.errors as errors
+
+from typing import Union
+
+ValidRequestSchemas = Union[
+    FetchCallSchema,
+    TagCallSchema,
+    TrainModelSchema
+]

--- a/skit_pipelines/api/models/errors.py
+++ b/skit_pipelines/api/models/errors.py
@@ -1,0 +1,7 @@
+from kfp_server_api import ApiException
+
+def kfp_invalid_name(message: str) -> ApiException:
+    return ApiException(
+        status=400,
+        reason=message
+    )

--- a/skit_pipelines/api/models/errors.py
+++ b/skit_pipelines/api/models/errors.py
@@ -1,7 +1,7 @@
 from kfp_server_api import ApiException
 
-def kfp_invalid_name(message: str) -> ApiException:
+def kfp_api_error(reason: str, status=503) -> ApiException:
     return ApiException(
-        status=400,
-        reason=message
+        status=status,
+        reason=reason
     )

--- a/skit_pipelines/constants.py
+++ b/skit_pipelines/constants.py
@@ -15,6 +15,9 @@ DB_PASSWORD = os.environ["DB_PASSWORD"]
 DB_USER = os.environ["DB_USER"]
 
 PROJECT_NAME = "skit-pipelines"
+CONFIG_DIR = "config/"
+CONFIG_FILE = "config.yaml"
+CONFIG_FILE_PATH = os.path.join(CONFIG_DIR, CONFIG_FILE)
 KAFKA_INSTANCE = os.environ.get("KAFKA_INSTANCE", "kafka:9092")
 
 VOICE_BOT_XLMR_LABEL_COL = ""
@@ -38,14 +41,6 @@ TRANSCRIPT = "transcript"
 MULTI_USER = "multi_user"
 KFP_RUN_FN = "create_run_from_pipeline_func"
 
-FETCH_CALLS_NAME = "fetch-calls"
-DEFAULT_FETCH_CALLS_API_RUN = "default-fetch-calls-run"
-
-TAG_CALLS_NAME = "tag-calls"
-DEFAULT_TAG_CALLS_API_RUN = "default-tag-calls-run"
-
-TRAIN_XLMR_NAME = "train-voicebot-xlmr"
-DEFAULT_XLMR_MODEL_API_RUN = "default-train-voicebot-xlmr-run"
 
 KF_USERNAME = os.environ["KF_USERNAME"]
 KF_PASSWORD = os.environ["KF_PASSWORD"]
@@ -76,10 +71,3 @@ def CONSTRUCT_COOKIE_TOKEN(cookie_dict):
 
 def GET_RUN_URL(namespace, id):
     return f"{PIPELINE_HOST_URL}/?ns={namespace}#/runs/details/{id}"
-
-KAFKA_TOPIC_MAP = {
- FETCH_CALLS_NAME: "data-pipeline",
- TAG_CALLS_NAME: "data-pipeline",
- 
- TRAIN_XLMR_NAME: "model-train-pipeline"  
-}

--- a/skit_pipelines/pipelines/fetch_n_tag_calls_pipeline.py
+++ b/skit_pipelines/pipelines/fetch_n_tag_calls_pipeline.py
@@ -57,7 +57,7 @@ def run_fetch_n_tag_calls(
     errors.display_name = "get-any-errors"
 
     notification_text = f"""Finished a request for {call_quantity} calls. Fetched from {start_date} to {end_date} for {client_id=}.
-        Uploaded {getattr(calls, 'output')} ({getattr(df_size, 'output')}, {org_id=}) for tagging to {job_id=}.\nErrors: {getattr(errors, 'output')}"""
+    Uploaded {getattr(calls, 'output')} ({getattr(df_size, 'output')}, {org_id=}) for tagging to {job_id=}.\nErrors: {getattr(errors, 'output')}"""
     
     with kfp.dsl.Condition(notify == True, "notify").after(errors) as check1:
         task_no_cache = slack_notification_op(notification_text, "")

--- a/skit_pipelines/utils/config.py
+++ b/skit_pipelines/utils/config.py
@@ -1,22 +1,66 @@
+from typing import Callable, Dict, List
+import yaml
+
 import skit_pipelines.constants as const
+import skit_pipelines.pipelines as pipelines
 
-from skit_pipelines.pipelines import (
-    run_fetch_calls,
-    run_tag_calls,
-    run_xlmr_train
-)
 
-RUN_NAME_MAP = {
-    const.FETCH_CALLS_NAME: const.DEFAULT_FETCH_CALLS_API_RUN,
-    const.TAG_CALLS_NAME: const.DEFAULT_TAG_CALLS_API_RUN,
-    const.TRAIN_XLMR_NAME: const.DEFAULT_XLMR_MODEL_API_RUN
-}
+def get_config(path):
+    with open(path, 'r') as stream:
+        try:
+            return yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
 
-PIPELINE_FN_MAP = {
-    const.FETCH_CALLS_NAME: run_fetch_calls,
-    const.TAG_CALLS_NAME: run_tag_calls,
-    const.TRAIN_XLMR_NAME: run_xlmr_train
-}
+class Config:
+    
+    @classmethod
+    def load(cls) -> 'Config':
+        config = cls()
+        config.RUN_NAME_MAP = config.get_run_name_map()
+        config.PIPELINE_FN_MAP = config.get_pipeline_fn_map()
+        config.KAFKA_TOPIC_MAP = config.get_publisher_topic_map()
+        return config
+    
+    def __init__(self, path=const.CONFIG_FILE_PATH):
+        self.config = get_config(path)
+    
+    def get_pipeline_configs(self) -> Dict[str, str]:
+        return self.config['pipelines']
+    
+    def get_pipeline_names(self) -> List[str]:
+        return list(self.get_pipeline_configs())
+    
+    def get_publisher_topics(self) -> List[str]:
+        return self.config['publisher_topics']
+    
+    def get_run_name_map(self) -> Dict[str, str]:
+        return {
+            pipeline_name: pipeline_config['default_run'] \
+                for pipeline_name, pipeline_config in self.get_pipeline_configs().items()
+        }
+    
+    def get_pipeline_fn_map(self) -> Dict[str, Callable]:
+        return {
+            pipeline_name: self.get_pipeline_fn(pipeline_config['main_function']) \
+                for pipeline_name, pipeline_config in self.get_pipeline_configs().items()
+        }
+    
+    def get_publisher_topic_map(self) -> Dict[str, str]:
+        return {
+            pipeline_name: pipeline_config['topic'] \
+                for pipeline_name, pipeline_config in self.get_pipeline_configs().items()
+        }
+    
+    def valid_pipeline(self, name: str) -> bool:
+        return name in self.get_pipeline_names()
+        
+    @staticmethod
+    def get_pipeline_fn(name: str) -> Callable:
+        try:
+            return getattr(pipelines, name)
+        except AttributeError:
+            raise AttributeError(f"Pipeline {name} does not exist, please check the name or create one first.")
 
-def valid_pipeline(pipeline_name: str) -> bool:
-    return pipeline_name in PIPELINE_FN_MAP.keys()
+
+config = Config.load()

--- a/skit_pipelines/utils/config.py
+++ b/skit_pipelines/utils/config.py
@@ -1,0 +1,22 @@
+import skit_pipelines.constants as const
+
+from skit_pipelines.pipelines import (
+    run_fetch_calls,
+    run_tag_calls,
+    run_xlmr_train
+)
+
+RUN_NAME_MAP = {
+    const.FETCH_CALLS_NAME: const.DEFAULT_FETCH_CALLS_API_RUN,
+    const.TAG_CALLS_NAME: const.DEFAULT_TAG_CALLS_API_RUN,
+    const.TRAIN_XLMR_NAME: const.DEFAULT_XLMR_MODEL_API_RUN
+}
+
+PIPELINE_FN_MAP = {
+    const.FETCH_CALLS_NAME: run_fetch_calls,
+    const.TAG_CALLS_NAME: run_tag_calls,
+    const.TRAIN_XLMR_NAME: run_xlmr_train
+}
+
+def valid_pipeline(pipeline_name: str) -> bool:
+    return pipeline_name in PIPELINE_FN_MAP.keys()


### PR DESCRIPTION
This PR helps by removing any need to write code for pipeline trigger endpoints. 
One would just have to fill out a [yaml](https://github.com/skit-ai/skit-pipelines/pull/15/files#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bba) based on their defined Pipeline code and endpoint would start working for that pipeline.

pipeline config structure:
```
fetch-calls:
        default_run: "default-fetch-calls-run"
        output_component: "fetch-calls"
        main_function: "run_fetch_calls"
        topic: "data-pipeline"
```
here,

`default_run` - the default run name by which the pipeline run will show up in kubeflow if no other run name is provided.
`output_component` - the s3_path yielding output component in the pipeline (here `_` will be replaced by `-`).
`main_function` - pipeline function name as defined in pipeline file.
`topic` - kafka topic in which to send it to once pipeline run finishes.

They'd still just have to define a new schema for the requests that the new pipeline will have - [here](https://github.com/skit-ai/skit-pipelines/pull/15/files#diff-81e637bb6d5284ddf9aaa3a3ab18956dd2d3354a7b2798686821503dc259701a) and [here](https://github.com/skit-ai/skit-pipelines/blob/71ec159b24171730149ed823fbc863bd10ceb15b/skit_pipelines/api/models/requests.py)