### PR TITLE
fix call_type default arg from "inbound" to "INBOUND" for fetch_calls_pipeline

### DIFF
--- a/skit_pipelines/pipelines/fetch_calls_pipeline/__init__.py
+++ b/skit_pipelines/pipelines/fetch_calls_pipeline/__init__.py
@@ -1,6 +1,5 @@
 import kfp
 
-from skit_pipelines import constants
 from skit_pipelines.components import fetch_calls_op, slack_notification_op
 
 

--- a/skit_pipelines/pipelines/fetch_calls_pipeline/__init__.py
+++ b/skit_pipelines/pipelines/fetch_calls_pipeline/__init__.py
@@ -70,7 +70,7 @@ def fetch_calls_pipeline(
     :type states: str, optional
     :param call_quantity: Number of calls to sample, defaults to 200
     :type call_quantity: int, optional
-    :param call_type: inbound, outbound vs subtesting call filters. We can currently choose only one of these, defaults to "inbound"
+    :param call_type: inbound, outbound vs subtesting call filters. We can currently choose only one of these, defaults to "INBOUND"
     :type call_type: str, optional
     :param notify: A comma separated list of slack ids: "@apples, @orange.fruit" etc, defaults to ""
     :type notify: str, optional

--- a/skit_pipelines/pipelines/fetch_calls_pipeline/__init__.py
+++ b/skit_pipelines/pipelines/fetch_calls_pipeline/__init__.py
@@ -1,5 +1,6 @@
 import kfp
 
+from skit_pipelines import constants
 from skit_pipelines.components import fetch_calls_op, slack_notification_op
 
 
@@ -20,7 +21,7 @@ def fetch_calls_pipeline(
     asr_provider: str = "",
     states: str = "",
     call_quantity: int = 200,
-    call_type: str = "inbound",
+    call_type: str = "INBOUND",
     notify: str = "",
     channel: str = "",
     slack_thread: str = "",


### PR DESCRIPTION
the default isn't working. 

Because of the default (`inbound`), we are getting empty csvs.
Therefore modified it to `INBOUND` to reflect how other pipelines have their defaults.