### PR TITLE
preprocess step skipped for lablestudio

### DIFF
--- a/skit_pipelines/components/eevee_irr_with_yamls.py
+++ b/skit_pipelines/components/eevee_irr_with_yamls.py
@@ -74,11 +74,11 @@ def eevee_irr_with_yamls(
         pred_labels[pipeline_constants.ID] = pred_labels[pipeline_constants.DATA_ID]
 
 
+    true_label_column =  pipeline_constants.INTENT_Y
+
     if labelstudio_project_id:
-        true_label_column =  "tag"
         pred_label_column = "intent"
     if tog_job_id:
-        true_label_column = "intent_y"
         pred_label_column = "raw.intent"
 
 
@@ -160,7 +160,7 @@ eevee_irr_with_yamls_op = kfp.components.create_component_from_func(
 )
 
 
-# if __name__ == "__main__":
+if __name__ == "__main__":
 
 #     _ = eevee_irr_with_yamls(
 #         data_path="mod_4242.csv",
@@ -190,3 +190,13 @@ eevee_irr_with_yamls_op = kfp.components.create_component_from_func(
     #     eevee_intent_groups_yaml_github_path="intents/indigo/groups.yaml",
     #     labelstudio_project_id=116
     # )
+
+    _ = eevee_irr_with_yamls(
+        data_path="sbi.csv",
+        output_path="metrics.pkl",
+        true_label_column="tag",
+        pred_label_column="intent",
+        # eevee_intent_alias_yaml_github_path="intents/indigo/alias.yaml",
+        # eevee_intent_groups_yaml_github_path="intents/indigo/groups.yaml",
+        labelstudio_project_id=152
+    )

--- a/skit_pipelines/components/preprocess/create_true_intent_column/__init__.py
+++ b/skit_pipelines/components/preprocess/create_true_intent_column/__init__.py
@@ -4,7 +4,12 @@ from kfp.components import InputPath, OutputPath
 from skit_pipelines import constants as pipeline_constants
 
 
-def create_intent_labels(data_path: InputPath(str), output_path: OutputPath(str)):
+def create_intent_labels(
+    data_path: InputPath(str), 
+    output_path: OutputPath(str),
+    tog_job_id = None,
+    labelstudio_project_id = None
+    ):
     import pandas as pd
     from loguru import logger
 
@@ -16,9 +21,16 @@ def create_intent_labels(data_path: InputPath(str), output_path: OutputPath(str)
     INTENT_Y = pipeline_constants.INTENT_Y
 
     train_df = pd.read_csv(data_path)
-    train_df[INTENT_Y] = train_df.tag.apply(pick_1st_tag)
-    logger.debug(train_df.intent_y[:10])
 
+    # preprocessing step needs to be skipped for labelstudio
+    # didn't do the `if tog_job_id:` to have backward compatability
+    # with tanmay's `eval_xlmr_pipeline`
+    if labelstudio_project_id:
+        pass
+    else:
+        train_df[INTENT_Y] = train_df.tag.apply(pick_1st_tag)
+        logger.debug(train_df.intent_y[:10])
+    
     train_df.to_csv(output_path, index=False)
 
 

--- a/skit_pipelines/components/preprocess/create_true_intent_column/__init__.py
+++ b/skit_pipelines/components/preprocess/create_true_intent_column/__init__.py
@@ -7,8 +7,6 @@ from skit_pipelines import constants as pipeline_constants
 def create_intent_labels(
     data_path: InputPath(str), 
     output_path: OutputPath(str),
-    tog_job_id = None,
-    labelstudio_project_id = None
     ):
     import pandas as pd
     from loguru import logger
@@ -21,15 +19,8 @@ def create_intent_labels(
     INTENT_Y = pipeline_constants.INTENT_Y
 
     train_df = pd.read_csv(data_path)
-
-    # preprocessing step needs to be skipped for labelstudio
-    # didn't do the `if tog_job_id:` to have backward compatability
-    # with tanmay's `eval_xlmr_pipeline`
-    if labelstudio_project_id:
-        pass
-    else:
-        train_df[INTENT_Y] = train_df.tag.apply(pick_1st_tag)
-        logger.debug(train_df.intent_y[:10])
+    train_df[INTENT_Y] = train_df.tag.apply(pick_1st_tag)
+    logger.debug(train_df.intent_y[:10])
     
     train_df.to_csv(output_path, index=False)
 
@@ -37,3 +28,8 @@ def create_intent_labels(
 create_true_intent_labels_op = kfp.components.create_component_from_func(
     create_intent_labels, base_image=pipeline_constants.BASE_IMAGE
 )
+
+
+if __name__ == "__main__":
+
+    create_intent_labels("87.csv", "bleh.csv")

--- a/skit_pipelines/components/preprocess/create_true_intent_column/utils.py
+++ b/skit_pipelines/components/preprocess/create_true_intent_column/utils.py
@@ -2,9 +2,30 @@ import json
 
 
 def pick_1st_tag(tag: str):
+
     try:
         tag = json.loads(tag)
-        tag, *_ = json.loads(tag) if isinstance(tag, str) else tag
-        return tag.get("type")
+
+        # if tag was applied json twice while serializing
+        if isinstance(tag, str):
+            tag = json.loads(tag)
+        
+        # since lablestudio and tog can have more than one tags
+        # for the same datapoint, we access only the first element
+        # from the json array
+        if isinstance(tag, list):
+            tag = tag[0]
+
+
+        if isinstance(tag, dict):
+
+            # labelstudio way of extracting the first intent
+            if "choices" in tag:
+                return tag["choices"][0]
+
+            # tog way of extracting the first intent
+            if "type" in tag:
+                return tag["type"]
+
     except json.JSONDecodeError:
         return tag

--- a/skit_pipelines/pipelines/irr_from_tog/__init__.py
+++ b/skit_pipelines/pipelines/irr_from_tog/__init__.py
@@ -180,7 +180,9 @@ def irr_from_tog(
 
     # Create true label column
     preprocess_data_op = create_true_intent_labels_op(
-        tagged_data_op.outputs["output"]
+        tagged_data_op.outputs["output"],
+        tog_job_id=job_id,
+        labelstudio_project_id=labelstudio_project_id
     ).after(tagged_data_op)
 
     with kfp.dsl.Condition(mlwr == False, "mlwr-publish-to-slack"):

--- a/skit_pipelines/pipelines/irr_from_tog/__init__.py
+++ b/skit_pipelines/pipelines/irr_from_tog/__init__.py
@@ -180,9 +180,7 @@ def irr_from_tog(
 
     # Create true label column
     preprocess_data_op = create_true_intent_labels_op(
-        tagged_data_op.outputs["output"],
-        tog_job_id=job_id,
-        labelstudio_project_id=labelstudio_project_id
+        tagged_data_op.outputs["output"]
     ).after(tagged_data_op)
 
     with kfp.dsl.Condition(mlwr == False, "mlwr-publish-to-slack"):


### PR DESCRIPTION
a very hackish way of handling preprocessing step.
done this way to handle:
* kubeflow having two huge repetitive components based on branching.
* backward compatibility with tanmay's xlmr eval pipeline. 

but lmk if there is a better way to do. :smiling_face_with_tear: 