### PR TITLE
upload2s3 upload directories, asr_tune uploads directory and process true transcript in asr_eval_pipeline

### DIFF
--- a/skit_pipelines/components/__init__.py
+++ b/skit_pipelines/components/__init__.py
@@ -30,6 +30,9 @@ from skit_pipelines.components.preprocess.create_true_intent_column import (
 from skit_pipelines.components.preprocess.create_true_transcript_column import (
     create_true_transcript_labels_op,
 )
+from skit_pipelines.components.preprocess.process_true_transcript_column import (
+    process_true_transcript_labels_op,
+)
 from skit_pipelines.components.preprocess.create_utterance_column import (
     create_utterances_op,
 )

--- a/skit_pipelines/components/preprocess/process_true_transcript_column/__init__.py
+++ b/skit_pipelines/components/preprocess/process_true_transcript_column/__init__.py
@@ -1,0 +1,31 @@
+import kfp
+from kfp.components import InputPath, OutputPath
+
+from skit_pipelines import constants as pipeline_constants
+
+
+def process_true_transcript_labels(
+    data_path: InputPath(str), true_label_column: str, output_path: OutputPath(str)
+):
+    import pandas as pd
+    from loguru import logger
+    import re
+
+    from skit_pipelines import constants as pipeline_constants
+    def process_true_transcript(transcript):
+        if type(transcript) != str: return ""
+        return re.sub(r'\<[^)]*?\>', '', transcript).strip()
+
+    train_df = pd.read_csv(data_path)
+    logger.debug("before processing:")
+    logger.debug(train_df[true_label_column][:15])
+    train_df[true_label_column] = train_df[true_label_column].apply(process_true_transcript)
+    logger.debug("after processing:")
+    logger.debug(train_df[true_label_column][:15])
+
+    train_df.to_csv(output_path, index=False)
+
+
+process_true_transcript_labels_op = kfp.components.create_component_from_func(
+    process_true_transcript_labels, base_image=pipeline_constants.BASE_IMAGE
+)

--- a/skit_pipelines/components/upload2s3.py
+++ b/skit_pipelines/components/upload2s3.py
@@ -14,6 +14,7 @@ def upload2s3(
     ext: str = ".csv",
     output_path: str = "",
     storage_options: str = "",
+    upload_as_directory: bool = True,
 ) -> str:
     import json
     import os
@@ -25,21 +26,32 @@ def upload2s3(
 
     from skit_pipelines.api.models import StorageOptions
     from skit_pipelines.utils import create_file_name
+    
+    def upload_s3_folder(s3_resource,bucket,path_on_disk,upload_path):
+        for root,dirs,files in os.walk(path_on_disk):
+            for file in files:
+                s3_resource.upload_file(os.path.join(root,file), bucket, os.path.join(upload_path,file))
 
     s3_resource = boto3.client("s3")
+
+    if upload_as_directory and ext:
+        raise ValueError("`upload_as_directory` can not be set with a non-empty `ext`")
 
     if storage_options:
         storage_options = StorageOptions(**json.loads(storage_options))
         bucket = storage_options.bucket
 
-    if os.path.isdir(path_on_disk):
+    if os.path.isdir(path_on_disk) and not upload_as_directory:
         _, tar_path = tempfile.mkstemp(suffix=".tar.gz")
         with tarfile.open(tar_path, "w:gz") as tar:
             tar.add(path_on_disk)
         path_on_disk = tar_path
 
     upload_path = output_path or create_file_name(reference, file_type, ext)
-    s3_resource.upload_file(path_on_disk, bucket, upload_path)
+    if not upload_as_directory:
+        s3_resource.upload_file(path_on_disk, bucket, upload_path)
+    else:
+        upload_s3_folder(s3_resource,bucket,path_on_disk,upload_path)
 
     s3_path = f"s3://{bucket}/{upload_path}"
     logger.debug(f"Uploaded {path_on_disk} to {upload_path}")

--- a/skit_pipelines/components/upload2s3.py
+++ b/skit_pipelines/components/upload2s3.py
@@ -14,7 +14,7 @@ def upload2s3(
     ext: str = ".csv",
     output_path: str = "",
     storage_options: str = "",
-    upload_as_directory: bool = True,
+    upload_as_directory: bool = False,
 ) -> str:
     import json
     import os

--- a/skit_pipelines/pipelines/asr_tune/__init__.py
+++ b/skit_pipelines/pipelines/asr_tune/__init__.py
@@ -61,9 +61,10 @@ def asr_tune(
 
     upload = upload2s3_op(
         path_on_disk=tune_op.outputs["output"],
-        bucket=BUCKET,
         output_path=target_model_path,
         storage_options=storage_options,
+        ext="",
+        upload_as_directory=True,
     )
     upload.execution_options.caching_strategy.max_cache_staleness = (
         "P0D"  # disables caching

--- a/skit_pipelines/pipelines/eval_asr_pipeline/__init__.py
+++ b/skit_pipelines/pipelines/eval_asr_pipeline/__init__.py
@@ -6,6 +6,7 @@ from skit_pipelines.components import (
     create_utterances_op,
     download_csv_from_s3_op,
     gen_asr_metrics_op,
+    process_true_transcript_labels_op,
     slack_notification_op,
     upload2s3_op,
 )
@@ -67,8 +68,12 @@ def eval_asr_pipeline(
         preprocess_data_op.outputs["output"], true_label_column
     ).after(preprocess_data_op)
 
+    preprocess_step_3_data_op = process_true_transcript_labels_op(
+        preprocess_step_2_data_op.outputs["output"], true_label_column,
+    ).after(preprocess_step_2_data_op)
+
     asr_metrics_op = gen_asr_metrics_op(
-        preprocess_step_2_data_op.outputs["output"],
+        preprocess_step_3_data_op.outputs["output"],
         true_label_column=true_label_column,
         pred_label_column=pred_label_column,
     )

--- a/skit_pipelines/pipelines/eval_asr_pipeline/__init__.py
+++ b/skit_pipelines/pipelines/eval_asr_pipeline/__init__.py
@@ -78,8 +78,9 @@ def eval_asr_pipeline(
         path_on_disk=asr_metrics_op.outputs["output"],
         reference=org_id,
         file_type="asr-metrics",
-        ext=".tgz",
         bucket=BUCKET,
+        ext="",
+        upload_as_directory=True,
     )
     upload_metrics.execution_options.caching_strategy.max_cache_staleness = (
         "P0D"  # disables caching

--- a/skit_pipelines/utils/__init__.py
+++ b/skit_pipelines/utils/__init__.py
@@ -15,7 +15,7 @@ def create_file_name(reference: str, file_type: str, ext=".csv") -> str:
         "project",
         str(reference),
         datetime.now().strftime("%Y-%m-%d"),
-        f"{reference}-{datetime.now().strftime('%Y-%m-%d')}-{file_type}{ext}",
+        f"{reference}-{datetime.now().strftime('%H-%M-%S')}-{file_type}{ext}",
     )
 
 


### PR DESCRIPTION
1. adding upload_as_directory argument to the upload2s3 component: can directly upload a directory to s3 instead of first compressing it to a .tar.gz. This change is backwards compatible.
2. a small fix in create_file_name function (used by the upload2s3 component)
3. updated some asr related pipelines to use the new argument in the upload2s3 component