### PR TITLE
Extending `retrain_slu` pipeline features

### DIFF
--- a/skit_pipelines/components/__init__.py
+++ b/skit_pipelines/components/__init__.py
@@ -8,6 +8,7 @@ from skit_pipelines.components.download_from_s3 import (
     download_file_from_s3_op,
 )
 from skit_pipelines.components.download_repo import download_repo_op
+from skit_pipelines.components.download_yaml import download_yaml_op
 from skit_pipelines.components.eevee_irr_with_yamls import eevee_irr_with_yamls_op
 from skit_pipelines.components.extract_info_from_dataset import (
     extract_info_from_dataset_op,

--- a/skit_pipelines/components/download_yaml.py
+++ b/skit_pipelines/components/download_yaml.py
@@ -1,0 +1,48 @@
+import kfp
+from kfp.components import OutputPath
+
+from skit_pipelines import constants as pipeline_constants
+
+def download_yaml(git_host_name: str, yaml_path: str, output_path: OutputPath(str)):
+    import traceback
+    from pprint import pprint
+    import requests
+    import yaml
+    from loguru import logger
+    from urllib.parse import urljoin
+
+    from skit_pipelines import constants as pipeline_constants
+    if not yaml_path:
+        logger.info("no yaml path provided")
+        with open(output_path, "w") as yaml_file:
+            yaml.safe_dump({}, yaml_file)
+        return
+
+    if git_host_name == pipeline_constants.GITHUB:
+        try:
+            yaml_url = urljoin(pipeline_constants.EEVEE_RAW_FILE_GITHUB_REPO_URL, yaml_path)
+            logger.debug(f"{yaml_url=}")
+            headers = requests.structures.CaseInsensitiveDict()
+            headers[
+                "Authorization"
+            ] = f"token {pipeline_constants.PERSONAL_ACCESS_TOKEN_GITHUB}"
+
+            response = requests.get(yaml_url, headers=headers)
+            logger.info(response.status_code)
+            if response.status_code == requests.codes.OK:
+
+                loaded_yaml = yaml.safe_load(response.content)
+
+                pprint(loaded_yaml)
+
+                with open(output_path, "w") as yaml_file:
+                    yaml.safe_dump(loaded_yaml, yaml_file)
+
+        except Exception as e:
+            logger.exception(e)
+            print(traceback.print_exc())
+
+
+download_yaml_op = kfp.components.create_component_from_func(
+    download_yaml, base_image=pipeline_constants.BASE_IMAGE
+)

--- a/skit_pipelines/components/retrain_slu_from_repo.py
+++ b/skit_pipelines/components/retrain_slu_from_repo.py
@@ -1,5 +1,3 @@
-from distutils.util import execute
-
 import kfp
 from kfp.components import InputPath, OutputPath
 
@@ -11,19 +9,29 @@ def retrain_slu_from_repo(
     s3_data_path: InputPath(str),
     annotated_job_data_path: InputPath(str),
     slu_path: InputPath(str),
+    intent_alias_path: InputPath(str),
+    bucket: str,
+    repo_name: str,
     branch: str,
     remove_intents: str = "",
     use_previous_dataset: bool = True,
     train_split_percent: int = 85,
     stratify: bool = False,
     epochs: int = 10,
-) -> str:
+    initial_training: bool = False,
+    job_ids: str = "",
+    labelstudio_project_ids: str = "",
+    s3_paths: str = "",
+    output_classification_report_path: OutputPath(str),
+    output_confusion_matrix_path: OutputPath(str)
+):
     import os
     import subprocess
     import tempfile
     from typing import Dict, List
 
     import git
+    import yaml
     import pandas as pd
     from loguru import logger
 
@@ -33,17 +41,8 @@ def retrain_slu_from_repo(
     )
     from skit_pipelines.utils.normalize import comma_sep_str
 
+
     execute_cli = lambda cmd: subprocess.run(cmd.split())
-    create_dataset_path = lambda version, dataset_type: os.path.join(
-        "data",
-        version,
-        "classification/datasets",
-        dataset_type + pipeline_constants.CSV_FILE,
-    )
-
-    remove_intents = comma_sep_str(remove_intents)
-    no_annotated_job = False
-
     def execute_cli_output(cmd):
         popen = subprocess.Popen(
             cmd.split(), stdout=subprocess.PIPE, universal_newlines=True
@@ -52,34 +51,64 @@ def retrain_slu_from_repo(
             yield stdout_line.rstrip("\n")
         popen.stdout.close()
         return_code = popen.wait()
-
         if return_code:
             raise subprocess.CalledProcessError(return_code, cmd)
+
+    create_dataset_path = lambda version, dataset_type: os.path.join(
+        "data",
+        version,
+        "classification/datasets",
+        dataset_type + pipeline_constants.CSV_FILE,
+    )
+   
+    def get_metrics_path(version, metric_type):
+        metrics_dir = os.path.join("data", version, "classification/metrics")
+        metrics_dir_walk = os.walk(metrics_dir)
+        return os.path.join(
+            metrics_dir, next(metrics_dir_walk)[1][0], next(metrics_dir_walk)[1][0],
+            metric_type + pipeline_constants.CSV_FILE
+        )
+
+    remove_intents = comma_sep_str(remove_intents)
+    no_annotated_job = False
 
     def get_slu_version():
         return next(execute_cli_output("poetry version -s"))
 
-    def smol_version_bump(version):
+    def smol_version_bump(version, skip=False):
         *parent, child = version.split(".")
         parent.append(str(int(child) + 1))
-        return ".".join(parent)
+        return version if skip else ".".join(parent)
 
     def filter_dataset(
         dataset_path: str,
         remove_intents: List[str],
         intent_col: str = pipeline_constants.TAG,
     ) -> None:
+        logger.info(f"filtering: {dataset_path=}\nwhile {remove_intents=}")
         dataset = pd.read_csv(dataset_path)
         dataset[~dataset[intent_col].isin(remove_intents)].to_csv(
             dataset_path, index=False
         )
 
     def alias_dataset(
-        dataset: pd.DataFrame, alias_intents_config: Dict[str, str]
+        dataset_path: str, alias_yaml_path: str, intent_col: str = pipeline_constants.TAG
     ) -> None:
-        pass
+        reverse_alias_config = {}
+        with open(alias_yaml_path, "r") as yaml_file:
+            alias_config = yaml.safe_load(yaml_file)
+        for map_to, map_from_values in alias_config.items():
+            for map_from in map_from_values:
+                reverse_alias_config[map_from] = map_to
+        logger.info(f"aliasing: {dataset_path=} with config={reverse_alias_config}")
+        dataset = pd.read_csv(dataset_path)
+        dataset.replace({intent_col: reverse_alias_config}).to_csv(
+            dataset_path, index=False
+        )
 
-    # TODO create slu alias-data command - not imp rn
+    data_info = f"{job_ids=}" if job_ids else '' + \
+                f" {labelstudio_project_ids=}" if labelstudio_project_ids else '' + \
+                f" {s3_paths=}" if s3_paths else ''
 
     os.chdir(slu_path)
     repo = git.Repo(".")
@@ -127,9 +156,23 @@ def retrain_slu_from_repo(
 
         execute_cli("pip install poetry -U")
         execute_cli("poetry install")
-        execute_cli("dvc pull data.dvc")
+
         current_slu_version = get_slu_version()
-        new_slu_version = smol_version_bump(current_slu_version)
+        new_slu_version = smol_version_bump(current_slu_version, skip=initial_training)
+
+        if not os.path.exists("data.dvc") and initial_training:
+            execute_cli(f"slu setup-dirs --version {current_slu_version}")
+            execute_cli(f"dvc init")
+            execute_cli(f"dvc add data")
+            execute_cli(f"dvc remote add -d s3remote s3://{bucket}/clients/{repo_name}/")
+            use_previous_dataset=False
+
+        elif not initial_training and os.path.exists("data.dvc"):
+            execute_cli("dvc pull data.dvc")
+
+        else:
+            raise ValueError(f"Discrepancy between setting {initial_training=} and repo containing data.dvc")
+        
         execute_cli(f"slu setup-dirs --version {new_slu_version}")
 
         current_train_path = create_dataset_path(
@@ -159,10 +202,9 @@ def retrain_slu_from_repo(
                     execute_cli(
                         f"slu combine-data --out {new_test_path} {current_test_path} {new_test_path}"
                     )
-                # apply filter on new test dataset
-                filter_dataset(new_test_path, remove_intents)
+            
         else:
-            # don't split dataset
+            # don't split dataset - use all as train set
             if use_previous_dataset:
                 # combine with older train dataset
                 execute_cli(
@@ -171,27 +213,43 @@ def retrain_slu_from_repo(
             else:
                 # copy new dataset to new path
                 execute_cli(f"cp {tagged_data_path} {new_train_path}")
-            # apply filter on new train dataset
-            filter_dataset(new_train_path, remove_intents)
-        # if alias then alias new train and new test set
+            # copy old test dataset to new path  
+            execute_cli(f"cp {current_test_path} {new_test_path}")
 
+        # alias and filter on new train set
+        alias_dataset(new_train_path, intent_alias_path)
+        filter_dataset(new_train_path, remove_intents)
+
+        # apply filter on new test dataset
+        filter_dataset(new_test_path, remove_intents)
+        alias_dataset(new_test_path, intent_alias_path)
+
+        # training begins
         execute_cli(f"slu train --version {new_slu_version} --epochs {epochs}")
         if os.path.exists(current_test_path):
+            test_df = pd.read_csv(new_test_path)
+            if "raw.intent" in test_df:
+                test_df.rename(columns={"raw.intent": "intent"}).to_csv(new_test_path, index=False)
+
             execute_cli(f"slu test --version {new_slu_version}")
+            if (classification_report_path := get_metrics_path(new_slu_version, pipeline_constants.CLASSIFICATION_REPORT)):
+                execute_cli(f"cp {classification_report_path} {output_classification_report_path}")
+            
+            if (confusion_matrix_path := get_metrics_path(new_slu_version, pipeline_constants.FULL_CONFUSION_MATRIX)):
+                execute_cli(f"cp {confusion_matrix_path} {output_confusion_matrix_path}")
 
-        logger.info("After training untracked files:", repo.untracked_files)
-
-        repo.index.add(["config/"])
+        execute_cli(f"git status")
+        repo.git.add(all=True)
+        execute_cli(f"git status")
+        
         repo.index.commit(
-            f"Trained {new_slu_version} model", author=author, committer=committer
-        )  # TODO - add more info like dataset used and all
+            f"Trained {new_slu_version} model using {data_info}", author=author, committer=committer
+        )
 
         execute_cli(f"slu release --version {new_slu_version} --auto")
 
     except git.GitCommandError as e:
         logger.error(f"{e}: Given {branch=} doesn't exist in the repo")
-
-    return new_slu_version
 
 
 retrain_slu_from_repo_op = kfp.components.create_component_from_func(

--- a/skit_pipelines/constants.py
+++ b/skit_pipelines/constants.py
@@ -241,3 +241,7 @@ def GET_GITLAB_REPO_URL(
 
 
 GITHUB = "github.com"
+
+
+CLASSIFICATION_REPORT = "classification_report"
+FULL_CONFUSION_MATRIX = "full_confusion_matrix"

--- a/skit_pipelines/utils/k8s.py
+++ b/skit_pipelines/utils/k8s.py
@@ -5,8 +5,12 @@ from skit_pipelines.api import models
 
 
 def get_pipeline_config_kfp(pipeline_name):
-    node_type = models.PodNodeSelectorMap[pipeline_name]
-    if node_type == const.CPU_NODE_LABEL:
-        return PipelineConf().set_default_pod_node_selector(
-            label_name=const.POD_NODE_SELECTOR_LABEL, value=node_type
-        )
+    ## since currently gpu node doesn't support all integrations with db,
+    ## we set default pipeline nodeselector to be CPU node
+    ## while setting gpu node only for the required component in pipeline.
+    
+    # node_type = models.PodNodeSelectorMap[pipeline_name]
+    # if node_type == const.CPU_NODE_LABEL:
+    return PipelineConf().set_default_pod_node_selector(
+        label_name=const.POD_NODE_SELECTOR_LABEL, value=const.CPU_NODE_LABEL #node_type
+    )


### PR DESCRIPTION
This PR takes care of following changes:

- Classification report output on test dataset to be present in outputs
- Aliasing support while retraining    
- More informative outputs once retraining is done
- First-time training should be possible
- Evaluation reports notification in slack

New component - `download_yaml_op` for downloading eevee yamls exclusively.