### PR TITLE
`retrain_slu` pipeline changes to align with new Deployment CI/CD for SLU

### DIFF
--- a/skit_pipelines/components/__init__.py
+++ b/skit_pipelines/components/__init__.py
@@ -11,6 +11,7 @@ from skit_pipelines.components.download_from_s3 import (
     download_file_from_s3_op,
 )
 from skit_pipelines.components.download_repo import download_repo_op
+from skit_pipelines.components.create_mr import create_mr_op
 from skit_pipelines.components.download_yaml import download_yaml_op
 from skit_pipelines.components.eevee_irr_with_yamls import eevee_irr_with_yamls_op
 from skit_pipelines.components.extract_info_from_dataset import (

--- a/skit_pipelines/components/create_mr.py
+++ b/skit_pipelines/components/create_mr.py
@@ -1,0 +1,46 @@
+from wsgiref import headers
+import kfp
+from kfp.components import OutputPath
+
+from skit_pipelines import constants as pipeline_constants
+
+
+def create_mr(
+    *, git_host_name: str,
+    repo_name: str,
+    project_path: str,
+    target_branch: str,
+    source_branch: str,
+    mr_title: str,
+) -> str:
+    import requests
+    from urllib.parse import urljoin
+    from loguru import logger
+
+    from skit_pipelines import constants as const
+
+    if git_host_name == const.GITLAB:
+        URL = urljoin(const.GITLAB_API_BASE, f"{project_path}/{repo_name}".replace("/", "%2F") ) + "/merge_requests?"
+        headers = {
+            "PRIVATE-TOKEN": const.GITLAB_PRIVATE_TOKEN
+        }
+        payload = {
+            "title": mr_title,
+            "source_branch": source_branch,
+            "target_branch": target_branch,
+            "remove_source_branch": True
+        }
+        logger.info(f"URL: {URL}")
+        resp = requests.post(url=URL, data=payload, headers=headers)
+        
+        if resp.status_code in [200, 201]:
+            web_url = resp.json()["web_url"]
+            logger.info("Created MR successfully!")
+            return web_url
+        else:
+            logger.error(f"{resp.status_code}, {resp.text}")
+            raise ValueError("Failed to create MR")
+
+create_mr_op = kfp.components.create_component_from_func(
+    create_mr, base_image=pipeline_constants.BASE_IMAGE
+)

--- a/skit_pipelines/constants.py
+++ b/skit_pipelines/constants.py
@@ -228,7 +228,8 @@ SLACK_BOT_NAME = "charon" if REGION == AP_SOUTH_1 else "charon-us"
 
 # VCS
 GITLAB = "gitlab.com"
-GITLAB_SLU_PROJECT_PATH = "vernacularai/ai/clients"
+GITLAB_API_BASE = f"https://{GITLAB}/api/v4/projects/"
+GITLAB_SLU_PROJECT_PATH = "skit-ai/slu"
 GITLAB_USER = "automation"
 GITLAB_USER_EMAIL = "automation@skit.ai"
 GITLAB_PRIVATE_TOKEN = os.environ["PERSONAL_ACCESS_TOKEN_GITLAB"]

--- a/skit_pipelines/constants.py
+++ b/skit_pipelines/constants.py
@@ -59,6 +59,8 @@ INTENT_Y = "intent_y"
 TRANSCRIPT_Y = "transcript_y"
 INTENT = "intent"
 STATE = "state"
+DATA = "data"
+OLD_DATA = "old_data"
 
 START_TOKEN = "<s>"
 END_TOKEN = "</s>"


### PR DESCRIPTION
This PR includes:
- supports new CI/CD changes and new [SLU template for branch based release](https://github.com/skit-ai/dialogy-template-simple-transformers/pull/105)
      - previously it was tag based releases (slu release)
- auto creates MR in gitlab after training for changes review