### PR TITLE
cache the poetry install step for faster docker builds and dev experience

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,11 @@ RUN poetry config virtualenvs.create false
 
 RUN conda install scipy
 
-COPY . .
+COPY poetry.lock pyproject.toml .
 
 RUN poetry install --only main && poetry install --only main
+
+COPY . .
 
 # install johnny.
 RUN curl -s https://api.github.com/repos/skit-ai/johnny/releases/latest \


### PR DESCRIPTION
Everytime there is a change in `pipeline_constants` or when code gets re-organised or when we add new env variables, we are required to re-build the image and `poetry install` runs again. This change will allow us to skip `poetry install` for such type of changes, there by increasing the speed of development.