### PR TITLE
[PL-997] adding more call metadata from upstream for CRR tagging

### DIFF
--- a/skit_pipelines/components/upload_for_call_and_slot_tagging/__init__.py
+++ b/skit_pipelines/components/upload_for_call_and_slot_tagging/__init__.py
@@ -17,7 +17,7 @@ def fetch_calls_for_slots(
     from skit_pipelines import constants as pipeline_constants
     from skit_pipelines.components import upload2s3
 
-    df = pd.read_csv(untagged_records_path, usecols=["call_uuid", "reftime"])
+    df = pd.read_csv(untagged_records_path, usecols=["call_uuid", "reftime", "call_type", "language", "call_end_status", "disposition", "flow_id", "flow_version", "flow_name", "call_duration"])
     df = df.drop_duplicates(subset=["call_uuid"])
 
     df["date"] = df["reftime"].apply(lambda x: parser.isoparse(x).strftime("%Y-%m-%d"))
@@ -25,10 +25,10 @@ def fetch_calls_for_slots(
         lambda x: f"{pipeline_constants.CONSOLE_URL}/{org_id}/call-report/#/call?uuid={x}"
     )
     df["language"] = language_code
-
-    df.drop(labels=["call_uuid", "reftime"], axis="columns", inplace=True)
     print(df.head())
     df.to_csv("op.csv", index=False)
+
+    print(df.columns)
 
     s3_path = upload2s3(
         "op.csv",
@@ -48,5 +48,5 @@ fetch_calls_for_slots_op = kfp.components.create_component_from_func(
 if __name__ == "__main__":
 
     fetch_calls_for_slots(
-        untagged_records_path="./indigo_untagged.csv", org_id="34", language_code="en"
+        untagged_records_path="./vi_ta.csv", org_id="65", language_code="ta"
     )


### PR DESCRIPTION
thanks to @biswaroop1547 efforts in upstream data, we now have access to call context information for CRR tagging.

successful india run is here:
https://kubeflow.skit.ai/_/pipeline/?ns=skit#/runs/details/885e82c3-933a-48a0-b04e-1df73f9a9fd8
slack replies here: https://skit-ai.slack.com/archives/C029FCA06MT/p1676467089024339
