### PR TITLE
Write DVC configs when pushing new SLU model

### DIFF
--- a/skit_pipelines/components/retrain_slu_from_repo/__init__.py
+++ b/skit_pipelines/components/retrain_slu_from_repo/__init__.py
@@ -514,12 +514,13 @@ def retrain_slu_from_repo(
         if os.path.exists(pipeline_constants.OLD_DATA):
             execute_cli(f"rm -Rf {pipeline_constants.OLD_DATA}")
 
-        execute_cli("dvc add data")
-        execute_cli("dvc push data")
-       
         execute_cli("dvc config core.no_scm true")
         execute_cli("dvc config core.hardlink_lock true")
-       
+        repo.git.add([".dvc/config"])
+
+        execute_cli("dvc add data")
+        execute_cli("dvc push data")
+
         execute_cli(f"git status")
         repo.git.add(["data.dvc"])
         execute_cli(f"git status")

--- a/skit_pipelines/components/retrain_slu_from_repo/__init__.py
+++ b/skit_pipelines/components/retrain_slu_from_repo/__init__.py
@@ -516,7 +516,10 @@ def retrain_slu_from_repo(
 
         execute_cli("dvc add data")
         execute_cli("dvc push data")
-
+       
+        execute_cli("dvc config core.no_scm true")
+        execute_cli("dvc config core.hardlink_lock true")
+       
         execute_cli(f"git status")
         repo.git.add(["data.dvc"])
         execute_cli(f"git status")


### PR DESCRIPTION
added two configs as part of the MR (for retrained model)

- `dvc config core.no_scm true`
- `dvc config core.hardlink_lock true`

these were previously being added in the CD agent [[ref](https://gitlab.com/skit-ai/slu/model-inference-service/-/blob/master/scripts/download_model.sh#L15)], and leading to issues due to multiple attempted writes (in parallel) to NFS storage

---
Example [alert](https://vernacular-ai.atlassian.net/browse/ALERT-2900): happening across all SLU deployments on a daily basis

---
Core-ML [issue](https://vernacular-ai.atlassian.net/browse/CMI-50)