### PR TITLE
No calls found from FSM shouldnt fail pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+1.1.5
+- [x] fix: No calls found from FSM shouldnt fail data_fetch pipelines
+
 1.1.4
 - [x] fix: Intent list was not coming in comprision file while training or evaluate slu.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skit-pipelines"
-version = "1.1.4"
+version = "1.1.5"
 description = "Kubeflow components for ml workflows at skit.ai."
 authors = ["ltbringer <amresh.venugopal@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
**Why**
Currently, whenever no calls are found while fetching from FSM, our pipelines fail which leads to unwanted confusion. Ideally we want this situation to be more transparently provided to the consumers

**What**
Add a `dsl.condition` that deals with this use-case 

P.S: This issue happens quite frequently and hence the special handling. In general, we want the pipeline to fail for each hiccups in the expected flow