### PR TITLE
Support for the new format of scenarios

### DIFF
--- a/skit_pipelines/components/sample_conversations_generator/__init__.py
+++ b/skit_pipelines/components/sample_conversations_generator/__init__.py
@@ -2,11 +2,11 @@ import kfp
 from kfp.components import OutputPath
 
 from skit_pipelines import constants as pipeline_constants
-from typing import List
+from typing import Optional
 
 def sample_conversations_generator(
         output_path: OutputPath(str),
-        scenarios: List[str],
+        scenarios: Optional[str],
         output_dir: str,
         filename: str,
         prompt: str,
@@ -98,6 +98,9 @@ def sample_conversations_generator(
     
     
     run_dir = 'data_generation/'
+    scenarios = [val.strip() for val in scenarios.split('::')]
+
+    logger.info(f"Scenarios : {scenarios}")
     
     repo_local_path = tempfile.mkdtemp()
     

--- a/skit_pipelines/pipelines/generate_sample_conversations/__init__.py
+++ b/skit_pipelines/pipelines/generate_sample_conversations/__init__.py
@@ -1,6 +1,6 @@
 import kfp
 from kfp.components import OutputPath
-from typing import List
+from typing import Optional
 
 from skit_pipelines import constants as pipeline_constants
 from skit_pipelines.components import (
@@ -17,7 +17,7 @@ from skit_pipelines.components import (
 )
 def generate_sample_conversations(
     *,
-    scenarios: List[str],
+    scenarios: Optional[str],
     prompt: str = "",
     output_dir: str = "",
     filename: str = "",


### PR DESCRIPTION
Support for new format of scenarios, where multiple scenarios are provided as a string with ' :: ' as delimiter between the string.
`e.g:  { "scenarios": "The user wants to talk to a human agent, so the agent transfers the call :: The user engages in small talk, but the agent brings back the conversation about the due payment :: The user says they don't owe the due amount, so the agent transfers the call to a human agent. "}`