### PR TITLE
refactor: Use newer python version for pipelines using skit-calls/lab…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,7 @@ docker_build_dev_image
 
 /pipeline_secrets
 /us_docker_build_dev_image
+.DS_Store
+.idea/
+.vscode/
+

--- a/skit_pipelines/components/asr_transcription.py
+++ b/skit_pipelines/components/asr_transcription.py
@@ -40,7 +40,7 @@ def audio_transcription(
         print_command=False,
     )
 
-    exec_shell("conda create -n condaenv python=3.8")
+    exec_shell("conda create -n condaenv python=3.11")
     exec_shell("echo 'conda activate condaenv' >> ~/.bashrc")
     # exec_shell("conda install python=3.6")
     exec_shell("source ~/.bashrc && conda install -n condaenv git pip")

--- a/skit_pipelines/components/evaluate_slu_from_repo/__init__.py
+++ b/skit_pipelines/components/evaluate_slu_from_repo/__init__.py
@@ -49,11 +49,12 @@ def evaluate_slu_from_repo(
         run_dir="custom_slu",
         run_cmd="task serve",
         runtime_env_var=f"PROJECT_DATA_PATH={os.path.join(project_config_local_path, '..')}",
+        python_version="3.11",
     )
     logger.info("customization repo setup successfully")
 
     setup_repo(
-        core_slu_repo_name, core_slu_repo_branch
+        core_slu_repo_name, core_slu_repo_branch, python_version="3.11",
     )
     logger.info("core slu repo setup successfully")
 

--- a/skit_pipelines/components/retrain_slu_from_repo/__init__.py
+++ b/skit_pipelines/components/retrain_slu_from_repo/__init__.py
@@ -71,12 +71,13 @@ def retrain_slu_from_repo(
         run_dir="custom_slu",
         run_cmd="task serve",
         runtime_env_var=f"PROJECT_DATA_PATH={os.path.join(project_config_local_path, '..')}",
+        python_version="3.11",
     )
     logger.info("customization repo setup successfully")
 
     # Setup core slu repo
     setup_repo(
-        core_slu_repo_name, core_slu_repo_branch
+        core_slu_repo_name, core_slu_repo_branch, python_version="3.11",
     )
     logger.info("core slu repo setup successfully")
 

--- a/skit_pipelines/components/utils_slu.py
+++ b/skit_pipelines/components/utils_slu.py
@@ -32,7 +32,7 @@ def setup_project_config_repo(repo_name, branch):
     return project_config_local_path
 
 
-def setup_repo(repo_name, repo_branch, run_dir=None, run_cmd=None, runtime_env_var=None):
+def setup_repo(repo_name, repo_branch, run_dir=None, run_cmd=None, runtime_env_var=None, python_version="3.8"):
     """
     Download a SLU repo and install all necessary dependencies (using conda) as found in its dockerfile.
     """
@@ -50,7 +50,7 @@ def setup_repo(repo_name, repo_branch, run_dir=None, run_cmd=None, runtime_env_v
 
     try:
         repo.git.checkout(repo_branch)
-        execute_cli(f"conda create -n {repo_name} -m python=3.8 -y")
+        execute_cli(f"conda create -n {repo_name} -m python={python_version} -y")
         os.system(". /conda/etc/profile.d/conda.sh")
         execute_cli(
                 f"conda run -n {repo_name} "


### PR DESCRIPTION
Use newer python version for specific pipelines whose components no longer work with older python versions (3.8 -> 3.11).